### PR TITLE
Add error feedback loop for AI agent tool execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,16 @@ composer tests    # cs + sa + test
 array{type: string, properties: array<string, array<string, mixed>>, required: list<string>}
 ```
 
+## Error Feedback Loop
+
+The agent loop automatically feeds tool execution errors back to the LLM:
+
+1. **Exception errors**: `Dispatcher` catches all `Throwable` → `ToolResult::error()` with `"{ExceptionClass}: {message}"` format
+2. **Status code errors**: `Dispatcher` checks `ResourceObject->code >= 400` → `ToolResult::error()` with `"{code}: {json_body}"` format
+3. **Unknown tools**: Tool not found in `ToolRegistry` → `ToolResult::error()` with `"Unknown tool: {name}"` format
+
+Error results are sent back to the LLM as `tool_result` messages with `is_error: true`, allowing the LLM to retry or respond appropriately. The constant `Dispatcher::ERROR_STATUS_THRESHOLD` (400) defines the threshold.
+
 ## Notes
 
 ### Parameter Description Resolution Priority

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ The agent loop automatically feeds tool execution errors back to the LLM:
 2. **Status code errors**: `Dispatcher` checks `ResourceObject->code >= 400` → `ToolResult::error()` with `"{code}: {json_body}"` format
 3. **Unknown tools**: Tool not found in `ToolRegistry` → `ToolResult::error()` with `"Unknown tool: {name}"` format
 
-Error results are sent back to the LLM as `tool_result` messages with `is_error: true`, allowing the LLM to retry or respond appropriately. The constant `Dispatcher::ERROR_STATUS_THRESHOLD` (400) defines the threshold.
+Error results are sent back to the LLM as `tool_result` messages with `is_error: true`, allowing the LLM to retry or respond appropriately. The error status threshold (400) is defined as a private constant in `Dispatcher`.
 
 ## Notes
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -302,6 +302,30 @@ ALPSプロファイルの`semantic`記述子から`title`または`doc.value`が
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## エラーフィードバックループ
+
+ツール実行が失敗した場合、エラーは自動的にLLMにフィードバックされ、LLMはパラメータを修正して再試行したり、別のアクションを取ることができます。例外ベースのエラーと非2xxステータスコードの両方に対応しています。
+
+```
+ユーザー: 「ユーザー999を削除して」
+  ↓
+LLM: tool_use → user_delete(id: 999)
+  ↓
+Dispatcher: 404 Not Found → ToolResult(isError: true)
+  ↓
+LLMがエラーを受信し、次のアクションを決定
+  ↓
+LLM: 「ユーザー999は見つかりませんでした。」
+```
+
+Dispatcherが検出するエラー:
+
+| エラー種別 | 例 | エラーメッセージ形式 |
+|-----------|---|-------------------|
+| 例外 | `ResourceNotFoundException` | `BEAR\Resource\Exception\ResourceNotFoundException: /user?id=999` |
+| ステータスコード | `$this->code = 400` | `400: {"error":"Validation failed"}` |
+| 未知のツール | 未登録のツール | `Unknown tool: foo_bar` |
+
 ## API
 
 ### インターフェイス

--- a/README.md
+++ b/README.md
@@ -302,6 +302,30 @@ When multiple sources provide descriptions, they are resolved in this order:
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## Error Feedback Loop
+
+When a tool execution fails, the error is automatically fed back to the LLM, which can then retry with corrected parameters or take alternative action. This works for both exception-based errors and non-2xx status codes.
+
+```
+User: "Delete user 999"
+  ↓
+LLM: tool_use → user_delete(id: 999)
+  ↓
+Dispatcher: 404 Not Found → ToolResult(isError: true)
+  ↓
+LLM receives error, decides next action
+  ↓
+LLM: "User 999 was not found."
+```
+
+Errors detected by the Dispatcher:
+
+| Error Type | Example | Error Message Format |
+|------------|---------|---------------------|
+| Exception | `ResourceNotFoundException` | `BEAR\Resource\Exception\ResourceNotFoundException: /user?id=999` |
+| Status code | `$this->code = 400` | `400: {"error":"Validation failed"}` |
+| Unknown tool | Tool not registered | `Unknown tool: foo_bar` |
+
 ## API
 
 ### Interfaces

--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -22,7 +22,7 @@ use const JSON_UNESCAPED_UNICODE;
  */
 final readonly class Dispatcher implements DispatcherInterface
 {
-    private const HTTP_ERROR_THRESHOLD = 400;
+    private const ERROR_STATUS_THRESHOLD = 400;
 
     public function __construct(
         private ResourceInterface $resource,
@@ -50,10 +50,10 @@ final readonly class Dispatcher implements DispatcherInterface
 
             $content = json_encode($ro->body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
-            if ($ro->code >= self::HTTP_ERROR_THRESHOLD) {
+            if ($ro->code >= self::ERROR_STATUS_THRESHOLD) {
                 return ToolResult::error(
                     $toolCall->id,
-                    sprintf('HTTP %d: %s', $ro->code, $content),
+                    sprintf('%d: %s', $ro->code, $content),
                 );
             }
 

--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -22,6 +22,8 @@ use const JSON_UNESCAPED_UNICODE;
  */
 final readonly class Dispatcher implements DispatcherInterface
 {
+    private const int HTTP_ERROR_THRESHOLD = 400;
+
     public function __construct(
         private ResourceInterface $resource,
         private ToolRegistryInterface $registry,
@@ -40,13 +42,22 @@ final readonly class Dispatcher implements DispatcherInterface
         }
 
         try {
-            $result = $this->executeResource(
+            $ro = $this->invokeResource(
                 $mapping['resourceUri'],
                 $mapping['method'],
                 $toolCall->input,
             );
 
-            return ToolResult::success($toolCall->id, $result);
+            $content = json_encode($ro->body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+            if ($ro->code >= self::HTTP_ERROR_THRESHOLD) {
+                return ToolResult::error(
+                    $toolCall->id,
+                    sprintf('HTTP %d: %s', $ro->code, $content),
+                );
+            }
+
+            return ToolResult::success($toolCall->id, $content);
         } catch (Throwable $e) {
             return ToolResult::error(
                 $toolCall->id,
@@ -56,7 +67,7 @@ final readonly class Dispatcher implements DispatcherInterface
     }
 
     /** @param array<string, mixed> $input */
-    private function executeResource(string $uri, string $method, array $input): string
+    private function invokeResource(string $uri, string $method, array $input): ResourceObject
     {
         $httpMethod = strtoupper($method);
 
@@ -70,6 +81,6 @@ final readonly class Dispatcher implements DispatcherInterface
             default => $this->resource->get($uri, $input),
         };
 
-        return json_encode($ro->body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        return $ro;
     }
 }

--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -22,7 +22,7 @@ use const JSON_UNESCAPED_UNICODE;
  */
 final readonly class Dispatcher implements DispatcherInterface
 {
-    private const int HTTP_ERROR_THRESHOLD = 400;
+    private const HTTP_ERROR_THRESHOLD = 400;
 
     public function __construct(
         private ResourceInterface $resource,

--- a/tests/Dispatch/DispatcherTest.php
+++ b/tests/Dispatch/DispatcherTest.php
@@ -176,7 +176,7 @@ final class DispatcherTest extends TestCase
         $result = $this->dispatcher->dispatch($toolCall);
 
         $this->assertTrue($result->isError);
-        $this->assertStringContainsString('HTTP 400', $result->content);
+        $this->assertStringContainsString('400:', $result->content);
         $this->assertStringContainsString('Validation failed', $result->content);
     }
 
@@ -188,7 +188,7 @@ final class DispatcherTest extends TestCase
         $result = $this->dispatcher->dispatch($toolCall);
 
         $this->assertTrue($result->isError);
-        $this->assertStringContainsString('HTTP 500', $result->content);
+        $this->assertStringContainsString('500:', $result->content);
     }
 
     public function testDispatchWithSuccessStatusCode(): void

--- a/tests/Dispatch/DispatcherTest.php
+++ b/tests/Dispatch/DispatcherTest.php
@@ -167,4 +167,37 @@ final class DispatcherTest extends TestCase
 
         $this->assertFalse($result->isError);
     }
+
+    public function testDispatchWithErrorStatusCode(): void
+    {
+        $this->registry->register('status_error_get', 'app://self/status-error', 'get');
+        $toolCall = new ToolCall('call_status', 'status_error_get', ['code' => 400]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertTrue($result->isError);
+        $this->assertStringContainsString('HTTP 400', $result->content);
+        $this->assertStringContainsString('Validation failed', $result->content);
+    }
+
+    public function testDispatchWithServerErrorStatusCode(): void
+    {
+        $this->registry->register('status_error_get', 'app://self/status-error', 'get');
+        $toolCall = new ToolCall('call_status', 'status_error_get', ['code' => 500]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertTrue($result->isError);
+        $this->assertStringContainsString('HTTP 500', $result->content);
+    }
+
+    public function testDispatchWithSuccessStatusCode(): void
+    {
+        $this->registry->register('crud_get', 'app://self/crud', 'get');
+        $toolCall = new ToolCall('call_success', 'crud_get', ['id' => 1]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertFalse($result->isError);
+    }
 }

--- a/tests/Fake/Resource/App/FakeNoDescriptionResource.php
+++ b/tests/Fake/Resource/App/FakeNoDescriptionResource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\ResourceObject;
+
+class FakeNoDescriptionResource extends ResourceObject
+{
+    #[JsonSchema(params: 'no_description.json')]
+    public function onGet(int $id): static
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/Resource/App/StatusError.php
+++ b/tests/Fake/Resource/App/StatusError.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+
+/**
+ * Resource that returns error HTTP status codes without throwing exceptions
+ */
+class StatusError extends ResourceObject
+{
+    public function onGet(int $code = 400): static
+    {
+        $this->code = $code;
+        $this->body = ['error' => 'Validation failed', 'details' => 'The "name" field is required'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/json_schema/no_description.json
+++ b/tests/Fake/json_schema/no_description.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "integer",
+            "minimum": 1
+        }
+    },
+    "required": ["id"]
+}

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -279,4 +279,154 @@ final class AgentTest extends TestCase
 
         $this->assertSame('Valid', $response->getText());
     }
+
+    public function testToolErrorFeedbackLoop(): void
+    {
+        // Register error tool
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('error_get', 'app://self/error', 'get');
+        $dispatcher = new Dispatcher($resource, $registry);
+
+        $tools = [
+            new Tool('error_get', 'Get error resource', [
+                'type' => 'object',
+                'properties' => [],
+                'required' => [],
+            ]),
+        ];
+
+        $llmClient = new FakeLlmClient();
+        $agent = new Agent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+
+        // 1st LLM call: returns tool_use → dispatch will fail with exception
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        // 2nd LLM call: LLM receives error, responds with text
+        $llmClient->queueTextResponse('The tool returned an error. Let me help you differently.');
+
+        $response = $agent->run('Call the error tool');
+
+        // Verify the agent completed after receiving error feedback
+        $this->assertTrue($response->completed);
+        $this->assertSame('The tool returned an error. Let me help you differently.', $response->getText());
+
+        // Verify the LLM received the error in its 2nd call
+        $this->assertCount(2, $llmClient->calls);
+        $secondCallMessages = $llmClient->calls[1]['messages'];
+        // Messages: [user, assistant(tool_use), user(tool_result with error)]
+        $this->assertCount(3, $secondCallMessages);
+        $toolResultMessage = $secondCallMessages[2];
+        $this->assertSame('user', $toolResultMessage->role);
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertStringContainsString('RuntimeException', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testToolErrorFeedbackLoopWithRetry(): void
+    {
+        // Register both error and success tools
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('error_get', 'app://self/error', 'get');
+        $registry->register('article_get', 'app://self/article', 'get');
+        $dispatcher = new Dispatcher($resource, $registry);
+
+        $tools = [
+            new Tool('error_get', 'Get error resource', [
+                'type' => 'object',
+                'properties' => [],
+                'required' => [],
+            ]),
+            new Tool('article_get', 'Get an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ]),
+        ];
+
+        $llmClient = new FakeLlmClient();
+        $agent = new Agent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+
+        // 1st LLM call: tries error tool → fails
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        // 2nd LLM call: LLM sees error, retries with different tool
+        $llmClient->queueToolUseResponse('call_2', 'article_get', ['id' => 1]);
+        // 3rd LLM call: LLM gets success result, returns completion
+        $llmClient->queueTextResponse('I found the article for you.');
+
+        $response = $agent->run('Find information');
+
+        // Agent should complete after error → retry → success
+        $this->assertTrue($response->completed);
+        $this->assertSame('I found the article for you.', $response->getText());
+
+        // Verify 3 LLM calls occurred (initial + error feedback + success feedback)
+        $this->assertCount(3, $llmClient->calls);
+
+        // Verify error was fed back in 2nd call
+        $secondCallMessages = $llmClient->calls[1]['messages'];
+        $toolResultMessage = $secondCallMessages[2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+
+        // Verify success was fed back in 3rd call
+        $thirdCallMessages = $llmClient->calls[2]['messages'];
+        $toolResultMessage = $thirdCallMessages[4];
+        $this->assertFalse($toolResultMessage->content[0]['is_error']);
+    }
+
+    public function testToolErrorFeedbackLoopWithStatusCode(): void
+    {
+        // Register status error tool
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('status_error_get', 'app://self/status-error', 'get');
+        $dispatcher = new Dispatcher($resource, $registry);
+
+        $tools = [
+            new Tool('status_error_get', 'Get status error resource', [
+                'type' => 'object',
+                'properties' => ['code' => ['type' => 'integer']],
+                'required' => [],
+            ]),
+        ];
+
+        $llmClient = new FakeLlmClient();
+        $agent = new Agent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+
+        // 1st LLM call: tries tool → returns 400 status
+        $llmClient->queueToolUseResponse('call_1', 'status_error_get', ['code' => 400]);
+        // 2nd LLM call: LLM sees HTTP 400 error, responds with guidance
+        $llmClient->queueTextResponse('The request failed with a validation error. The "name" field is required.');
+
+        $response = $agent->run('Call the status error tool');
+
+        $this->assertTrue($response->completed);
+
+        // Verify the LLM received the HTTP status error
+        $secondCallMessages = $llmClient->calls[1]['messages'];
+        $toolResultMessage = $secondCallMessages[2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertStringContainsString('HTTP 400', $toolResultMessage->content[0]['content']);
+        $this->assertStringContainsString('Validation failed', $toolResultMessage->content[0]['content']);
+    }
 }

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -426,7 +426,7 @@ final class AgentTest extends TestCase
         $secondCallMessages = $llmClient->calls[1]['messages'];
         $toolResultMessage = $secondCallMessages[2];
         $this->assertTrue($toolResultMessage->content[0]['is_error']);
-        $this->assertStringContainsString('HTTP 400', $toolResultMessage->content[0]['content']);
+        $this->assertStringContainsString('400:', $toolResultMessage->content[0]['content']);
         $this->assertStringContainsString('Validation failed', $toolResultMessage->content[0]['content']);
     }
 }

--- a/tests/Schema/ParameterDescriptionResolverTest.php
+++ b/tests/Schema/ParameterDescriptionResolverTest.php
@@ -8,6 +8,7 @@ use BEAR\ToolUse\Fake\Resource\App\FakeDocParamResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeEmptyDocResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeJsonSchemaResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeMissingParamDocResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeNoDescriptionResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeSnakeCaseResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeUserResource;
 use Koriym\AppStateDiagram\LabelNameTitle;
@@ -181,6 +182,23 @@ final class ParameterDescriptionResolverTest extends TestCase
 
         $description = $resolver->resolve($param, null);
 
+        $this->assertNull($description);
+    }
+
+    public function testReturnsNullWhenJsonSchemaHasNoDescription(): void
+    {
+        $docBlockFactory = DocBlockFactory::createInstance();
+        $jsonSchemaRepository = new JsonSchemaRepository(__DIR__ . '/../Fake/json_schema');
+        $resolver = new ParameterDescriptionResolver($docBlockFactory, $jsonSchemaRepository);
+
+        $reflection = new ReflectionClass(FakeNoDescriptionResource::class);
+        $method = $reflection->getMethod('onGet');
+        $param = $method->getParameters()[0]; // id (has schema but no description)
+
+        $jsonSchema = $jsonSchemaRepository->getParameterSchema(FakeNoDescriptionResource::class, 'onGet');
+        $description = $resolver->resolve($param, $jsonSchema);
+
+        // Should return null because JSON Schema property has no description
         $this->assertNull($description);
     }
 }


### PR DESCRIPTION
Dispatcher now detects non-2xx HTTP status codes from ResourceObject and returns ToolResult::error() so the LLM can see the error and retry with corrected parameters. Previously, only exceptions were caught as errors.

https://claude.ai/code/session_01HarFnrG32hStjFZuPjFexx