### PR TITLE
feat: Add human-in-the-loop confirmation for destructive tool calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ The agent supports user confirmation before executing destructive tool calls.
 
 1. `#[Tool(confirm: true)]` marks tools as confirmable (class or method level)
 2. `SchemaConverter::resolveConfirm()` reads confirm flag (method attribute takes priority over class)
-3. `Schema\Tool::$confirm` stores the flag (excluded from `jsonSerialize()` — not sent to LLM)
+3. `Schema\Tool::$confirm` stores the flag (included in `jsonSerialize()` as `confirm: true` only when true)
 4. `Agent::isCancelled()` checks if tool requires confirmation and calls `ConfirmationHandlerInterface`
 5. On cancellation, `ToolResult::error()` sends `"User cancelled this operation."` back to LLM
 
@@ -132,7 +132,7 @@ The agent supports user confirmation before executing destructive tool calls.
 - `ConfirmationHandlerInterface` is user-implemented (like `LlmClientInterface`)
 - LLM's text response serves as the confirmation message (no templates needed)
 - If no handler is bound, confirmable tools execute normally (no blocking)
-- The `confirm` property is internal metadata — never serialized to the LLM
+- The `confirm` property is serialized to JSON only when `true` (omitted when `false`)
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ composer tests    # cs + sa + test
 
 ## Testing
 
+- 100% code coverage is mandatory
 - Fake implementations in `tests/Fake/`
 - `FakeLlmClient` simulates LLM responses
 - `FakeConfirmationHandler` simulates user confirmation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ The agent supports user confirmation before executing destructive tool calls.
 ### How it works
 
 1. `#[Tool(confirm: true)]` marks tools as confirmable (class or method level)
-2. `SchemaConverter::resolveConfirm()` reads confirm flag (method attribute takes priority over class)
+2. `SchemaConverter::resolveConfirm()` reads confirm flag (explicit method confirm takes priority, unset falls back to class)
 3. `Schema\Tool::$confirm` stores the flag (included in `jsonSerialize()` as `confirm: true` only when true)
 4. `Agent::isCancelled()` checks if tool requires confirmation and calls `ConfirmationHandlerInterface`
 5. On cancellation, `ToolResult::error()` sends `"User cancelled this operation."` back to LLM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ A library that enables AI agent capabilities for BEAR.Sunday applications. Autom
 ```
 src/
 ├── Attribute/           # PHP Attributes
-│   ├── Tool.php         # Tool metadata (name, description)
+│   ├── Tool.php         # Tool metadata (name, description, confirm)
 │   └── Exclude.php      # Exclude from tool exposure
 ├── Dispatch/            # Tool execution
 │   ├── DispatcherInterface.php
@@ -36,6 +36,7 @@ src/
 │   ├── Agent.php        # Agent loop
 │   ├── AgentFactory.php # Agent builder
 │   ├── AgentResponse.php
+│   ├── ConfirmationHandlerInterface.php # User confirmation
 │   └── Message.php
 ├── Llm/                 # LLM related
 │   ├── LlmClientInterface.php  # User implementation
@@ -67,7 +68,8 @@ composer tests    # cs + sa + test
 ### BEAR.Sunday Integration
 
 - Expose resource classes as tools via full URI (`app://self/user`, `page://self/article`)
-- `#[Tool]` attribute for metadata customization (name, description)
+- `#[Tool]` attribute for metadata customization (name, description, confirm)
+- `#[Tool(confirm: true)]` requires user confirmation before tool execution
 - `#[Exclude]` attribute to exclude methods/classes from tool exposure (opt-out)
 - Supports BEAR\Resource\Annotation\JsonSchema for parameter validation
 
@@ -87,6 +89,7 @@ composer tests    # cs + sa + test
 
 - Fake implementations in `tests/Fake/`
 - `FakeLlmClient` simulates LLM responses
+- `FakeConfirmationHandler` simulates user confirmation
 - Fake resource classes in `tests/Fake/Resource/App/`
 
 ## Key Type Definitions
@@ -111,6 +114,25 @@ The agent loop automatically feeds tool execution errors back to the LLM:
 3. **Unknown tools**: Tool not found in `ToolRegistry` → `ToolResult::error()` with `"Unknown tool: {name}"` format
 
 Error results are sent back to the LLM as `tool_result` messages with `is_error: true`, allowing the LLM to retry or respond appropriately. The error status threshold (400) is defined as a private constant in `Dispatcher`.
+
+## Human-in-the-Loop Confirmation
+
+The agent supports user confirmation before executing destructive tool calls.
+
+### How it works
+
+1. `#[Tool(confirm: true)]` marks tools as confirmable (class or method level)
+2. `SchemaConverter::resolveConfirm()` reads confirm flag (method attribute takes priority over class)
+3. `Schema\Tool::$confirm` stores the flag (excluded from `jsonSerialize()` — not sent to LLM)
+4. `Agent::isCancelled()` checks if tool requires confirmation and calls `ConfirmationHandlerInterface`
+5. On cancellation, `ToolResult::error()` sends `"User cancelled this operation."` back to LLM
+
+### Key design decisions
+
+- `ConfirmationHandlerInterface` is user-implemented (like `LlmClientInterface`)
+- LLM's text response serves as the confirmation message (no templates needed)
+- If no handler is bound, confirmable tools execute normally (no blocking)
+- The `confirm` property is internal metadata — never serialized to the LLM
 
 ## Notes
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -193,6 +193,75 @@ use BEAR\ToolUse\Attribute\Tool;
 public function onGet(string $query): static { /* ... */ }
 ```
 
+## Human-in-the-Loop 確認
+
+`confirm: true` を指定すると、破壊的なツール呼び出しの実行前にユーザーの確認を求めます。
+
+### 確認が必要なツールの指定
+
+```php
+use BEAR\ToolUse\Attribute\Tool;
+
+// クラスレベル - 全メソッドで確認が必要
+#[Tool(confirm: true)]
+class User extends ResourceObject
+{
+    public function onGet(int $id): static { /* ... */ }
+    public function onDelete(int $id): static { /* ... */ }
+}
+
+// メソッドレベル - 特定のメソッドのみ確認が必要
+class Article extends ResourceObject
+{
+    public function onGet(int $id): static { /* ... */ }
+
+    #[Tool(confirm: true)]
+    public function onDelete(int $id): static { /* ... */ }
+}
+```
+
+### 確認ハンドラーの実装
+
+```php
+use BEAR\ToolUse\Runtime\ConfirmationHandlerInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+
+final class CliConfirmationHandler implements ConfirmationHandlerInterface
+{
+    public function confirm(ToolCall $toolCall, string $llmText): bool
+    {
+        echo $llmText . "\n実行しますか？ [Y/n]: ";
+
+        return trim(fgets(STDIN)) !== 'n';
+    }
+}
+```
+
+### DIモジュールでのバインド
+
+```php
+$this->bind(ConfirmationHandlerInterface::class)->to(CliConfirmationHandler::class);
+```
+
+### 動作の仕組み
+
+LLMのテキストレスポンスが確認メッセージとして使われます。テンプレートは不要です。
+
+```
+ユーザー: 「記事123を削除して」
+  ↓
+LLM: 「記事ID 123「BEAR.Sundayの紹介」を削除します。」
+     tool_use: article_delete({id: 123})
+  ↓
+ConfirmationHandler: 「記事ID 123「BEAR.Sundayの紹介」を削除します。」
+                     実行しますか？ [Y/n]:
+  ↓
+Y → ツール実行
+N → "User cancelled this operation." → LLM: 「承知しました。」
+```
+
+`ConfirmationHandlerInterface` がバインドされていない場合、確認対象ツールも通常通り実行されます（ブロックなし）。
+
 ## JSON Schemaの統合
 
 BEAR.ResourceのJSON Schemaを使用してパラメータ定義を強化できます。
@@ -338,6 +407,7 @@ Dispatcherが検出するエラー:
 | `SchemaConverterInterface` | リソースからツール定義への変換 |
 | `ToolCollectorInterface` | ツールの収集と登録 |
 | `AgentInterface` | エージェントランタイム |
+| `ConfirmationHandlerInterface` | 破壊的ツールのユーザー確認 |
 
 ### 主要クラス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -232,7 +232,9 @@ final class CliConfirmationHandler implements ConfirmationHandlerInterface
     {
         echo $llmText . "\n実行しますか？ [Y/n]: ";
 
-        return trim(fgets(STDIN)) !== 'n';
+        $line = fgets(STDIN);
+
+        return $line !== false && trim($line) !== 'n';
     }
 }
 ```
@@ -247,7 +249,7 @@ $this->bind(ConfirmationHandlerInterface::class)->to(CliConfirmationHandler::cla
 
 LLMのテキストレスポンスが確認メッセージとして使われます。テンプレートは不要です。
 
-```
+```text
 ユーザー: 「記事123を削除して」
   ↓
 LLM: 「記事ID 123「BEAR.Sundayの紹介」を削除します。」

--- a/README.md
+++ b/README.md
@@ -193,6 +193,75 @@ use BEAR\ToolUse\Attribute\Tool;
 public function onGet(string $query): static { /* ... */ }
 ```
 
+## Human-in-the-Loop Confirmation
+
+Add `confirm: true` to require user confirmation before executing destructive tool calls.
+
+### Mark Tools as Confirmable
+
+```php
+use BEAR\ToolUse\Attribute\Tool;
+
+// Class level - all methods require confirmation
+#[Tool(confirm: true)]
+class User extends ResourceObject
+{
+    public function onGet(int $id): static { /* ... */ }
+    public function onDelete(int $id): static { /* ... */ }
+}
+
+// Method level - only specific methods require confirmation
+class Article extends ResourceObject
+{
+    public function onGet(int $id): static { /* ... */ }
+
+    #[Tool(confirm: true)]
+    public function onDelete(int $id): static { /* ... */ }
+}
+```
+
+### Implement Confirmation Handler
+
+```php
+use BEAR\ToolUse\Runtime\ConfirmationHandlerInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+
+final class CliConfirmationHandler implements ConfirmationHandlerInterface
+{
+    public function confirm(ToolCall $toolCall, string $llmText): bool
+    {
+        echo $llmText . "\nProceed? [Y/n]: ";
+
+        return trim(fgets(STDIN)) !== 'n';
+    }
+}
+```
+
+### Bind in DI Module
+
+```php
+$this->bind(ConfirmationHandlerInterface::class)->to(CliConfirmationHandler::class);
+```
+
+### How It Works
+
+The LLM's text response serves as the confirmation message. No templates needed.
+
+```
+User: "Delete article 123"
+  ↓
+LLM: "I will delete article 123 'Introduction to BEAR.Sunday'."
+     tool_use: article_delete({id: 123})
+  ↓
+ConfirmationHandler: "I will delete article 123 'Introduction to BEAR.Sunday'."
+                     Proceed? [Y/n]:
+  ↓
+Y → Tool executed
+N → "User cancelled this operation." → LLM: "Understood."
+```
+
+If no `ConfirmationHandlerInterface` is bound, confirmable tools execute normally (no blocking).
+
 ## JSON Schema Integration
 
 Use BEAR.Resource's JSON Schema for enhanced parameter definitions.
@@ -338,6 +407,7 @@ Errors detected by the Dispatcher:
 | `SchemaConverterInterface` | Converts resources to tool definitions |
 | `ToolCollectorInterface` | Collects and registers tools |
 | `AgentInterface` | Agent runtime |
+| `ConfirmationHandlerInterface` | User confirmation for destructive tools |
 
 ### Main Classes
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ final class CliConfirmationHandler implements ConfirmationHandlerInterface
     {
         echo $llmText . "\nProceed? [Y/n]: ";
 
-        return trim(fgets(STDIN)) !== 'n';
+        $line = fgets(STDIN);
+
+        return $line !== false && trim($line) !== 'n';
     }
 }
 ```
@@ -247,7 +249,7 @@ $this->bind(ConfirmationHandlerInterface::class)->to(CliConfirmationHandler::cla
 
 The LLM's text response serves as the confirmation message. No templates needed.
 
-```
+```text
 User: "Delete article 123"
   ↓
 LLM: "I will delete article 123 'Introduction to BEAR.Sunday'."

--- a/src/Attribute/Tool.php
+++ b/src/Attribute/Tool.php
@@ -10,7 +10,7 @@ use Attribute;
  * Defines tool metadata for AI agents
  *
  * @codeCoverageIgnore
- * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+ * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 final class Tool

--- a/src/Attribute/Tool.php
+++ b/src/Attribute/Tool.php
@@ -17,6 +17,7 @@ final class Tool
     public function __construct(
         public string|null $name = null,
         public string|null $description = null,
+        public bool $confirm = false,
     ) {
     }
 }

--- a/src/Attribute/Tool.php
+++ b/src/Attribute/Tool.php
@@ -10,6 +10,7 @@ use Attribute;
  * Defines tool metadata for AI agents
  *
  * @codeCoverageIgnore
+ * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 final class Tool

--- a/src/Attribute/Tool.php
+++ b/src/Attribute/Tool.php
@@ -18,7 +18,7 @@ final class Tool
     public function __construct(
         public string|null $name = null,
         public string|null $description = null,
-        public bool $confirm = false,
+        public bool|null $confirm = null,
     ) {
     }
 }

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -110,21 +110,28 @@ final class Agent implements AgentInterface
     {
         $toolResults = [];
         foreach ($response->toolCalls as $toolCall) {
-            if ($this->requiresConfirmation($toolCall)) {
-                $llmText             = $response->getText();
-                $confirmationHandler = $this->confirmationHandler;
-                assert($confirmationHandler instanceof ConfirmationHandlerInterface);
-                if (! $confirmationHandler->confirm($toolCall, $llmText)) {
-                    $toolResults[] = ToolResult::error($toolCall->id, self::CANCELLED_MESSAGE);
+            if ($this->isCancelled($toolCall, $response)) {
+                $toolResults[] = ToolResult::error($toolCall->id, self::CANCELLED_MESSAGE);
 
-                    continue;
-                }
+                continue;
             }
 
             $toolResults[] = $this->dispatcher->dispatch($toolCall);
         }
 
         return $toolResults;
+    }
+
+    private function isCancelled(ToolCall $toolCall, LlmResponse $response): bool
+    {
+        if (! $this->requiresConfirmation($toolCall)) {
+            return false;
+        }
+
+        $confirmationHandler = $this->confirmationHandler;
+        assert($confirmationHandler instanceof ConfirmationHandlerInterface);
+
+        return ! $confirmationHandler->confirm($toolCall, $response->getText());
     }
 
     private function requiresConfirmation(ToolCall $toolCall): bool

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace BEAR\ToolUse\Runtime;
 
 use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Llm\LlmClientInterface;
+use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Schema\Tool;
 use Override;
+
+use function array_key_exists;
+use function assert;
 
 /**
  * Agent runtime for managing LLM conversation loop
@@ -17,8 +23,13 @@ use Override;
  */
 final class Agent implements AgentInterface
 {
+    private const CANCELLED_MESSAGE = 'User cancelled this operation.';
+
     /** @var list<Message> */
     public array $messages = [];
+
+    /** @var array<string, bool> */
+    private readonly array $confirmableTools;
 
     /** @param list<Tool> $tools */
     public function __construct(
@@ -27,7 +38,18 @@ final class Agent implements AgentInterface
         private readonly array $tools,
         private readonly string $systemPrompt,
         private readonly int $maxIterations = 10,
+        private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
     ) {
+        $confirmable = [];
+        foreach ($this->tools as $tool) {
+            if (! $tool->confirm) {
+                continue;
+            }
+
+            $confirmable[$tool->name] = true;
+        }
+
+        $this->confirmableTools = $confirmable;
     }
 
     /**
@@ -53,12 +75,7 @@ final class Agent implements AgentInterface
 
                 case 'tool_use':
                     $this->messages[] = Message::assistant($response->content);
-                    $toolResults = [];
-                    foreach ($response->toolCalls as $toolCall) {
-                        $result = $this->dispatcher->dispatch($toolCall);
-                        $toolResults[] = $result;
-                    }
-
+                    $toolResults      = $this->processToolCalls($response);
                     $this->messages[] = Message::toolResults($toolResults);
                     break;
 
@@ -86,5 +103,33 @@ final class Agent implements AgentInterface
     public function reset(): void
     {
         $this->messages = [];
+    }
+
+    /** @return list<ToolResult> */
+    private function processToolCalls(LlmResponse $response): array
+    {
+        $toolResults = [];
+        foreach ($response->toolCalls as $toolCall) {
+            if ($this->requiresConfirmation($toolCall)) {
+                $llmText             = $response->getText();
+                $confirmationHandler = $this->confirmationHandler;
+                assert($confirmationHandler instanceof ConfirmationHandlerInterface);
+                if (! $confirmationHandler->confirm($toolCall, $llmText)) {
+                    $toolResults[] = ToolResult::error($toolCall->id, self::CANCELLED_MESSAGE);
+
+                    continue;
+                }
+            }
+
+            $toolResults[] = $this->dispatcher->dispatch($toolCall);
+        }
+
+        return $toolResults;
+    }
+
+    private function requiresConfirmation(ToolCall $toolCall): bool
+    {
+        return $this->confirmationHandler !== null
+            && array_key_exists($toolCall->name, $this->confirmableTools);
     }
 }

--- a/src/Runtime/AgentFactory.php
+++ b/src/Runtime/AgentFactory.php
@@ -23,6 +23,7 @@ final class AgentFactory
         private readonly DispatcherInterface $dispatcher,
         private readonly ToolCollectorInterface $collector,
         private readonly ToolRegistryInterface $registry,
+        private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
     ) {
     }
 
@@ -54,6 +55,7 @@ final class AgentFactory
             tools: $this->tools,
             systemPrompt: $systemPrompt,
             maxIterations: $maxIterations,
+            confirmationHandler: $this->confirmationHandler,
         );
     }
 

--- a/src/Runtime/ConfirmationHandlerInterface.php
+++ b/src/Runtime/ConfirmationHandlerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\ToolCall;
+
+/**
+ * Handles user confirmation before executing destructive tool calls
+ *
+ * Implement this interface to control how confirmation is presented to the user.
+ * The LLM's text response serves as the confirmation message.
+ *
+ * @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
+ */
+interface ConfirmationHandlerInterface
+{
+    /**
+     * Ask user for confirmation before executing a tool call
+     *
+     * @param ToolCall $toolCall The tool call awaiting confirmation
+     * @param string   $llmText  Text from LLM response explaining the action
+     *
+     * @return bool True to proceed with execution, false to cancel
+     */
+    public function confirm(ToolCall $toolCall, string $llmText): bool;
+}

--- a/src/Runtime/ConfirmationHandlerInterface.php
+++ b/src/Runtime/ConfirmationHandlerInterface.php
@@ -11,8 +11,6 @@ use BEAR\ToolUse\Dispatch\ToolCall;
  *
  * Implement this interface to control how confirmation is presented to the user.
  * The LLM's text response serves as the confirmation message.
- *
- * @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
  */
 interface ConfirmationHandlerInterface
 {

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -82,13 +82,23 @@ final readonly class SchemaConverter implements SchemaConverterInterface
         $httpMethod = strtolower(str_replace('on', '', $method->getName()));
         $name = $this->buildToolName($resourcePath, $httpMethod, $methodAttribute);
         $description = $this->buildDescription($method, $classAttribute, $methodAttribute);
+        $confirm = $this->resolveConfirm($classAttribute, $methodAttribute);
 
         // Load JSON Schema for this method if available
         $jsonSchema = $this->jsonSchemaRepository?->getParameterSchema($resourceClass, $method->getName());
 
         $inputSchema = $this->buildInputSchema($method, $jsonSchema);
 
-        return new Tool($name, $description, $inputSchema);
+        return new Tool($name, $description, $inputSchema, $confirm);
+    }
+
+    private function resolveConfirm(ToolAttribute|null $classAttribute, ToolAttribute|null $methodAttribute): bool
+    {
+        if ($methodAttribute !== null) {
+            return $methodAttribute->confirm;
+        }
+
+        return $classAttribute?->confirm ?? false;
     }
 
     private function buildToolName(string $resourcePath, string $httpMethod, ToolAttribute|null $attribute): string

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -94,7 +94,10 @@ final readonly class SchemaConverter implements SchemaConverterInterface
 
     private function resolveConfirm(ToolAttribute|null $classAttribute, ToolAttribute|null $methodAttribute): bool
     {
-        return $methodAttribute?->confirm ?? $classAttribute?->confirm ?? false;
+        $confirm = $methodAttribute?->confirm;
+        $confirm ??= $classAttribute?->confirm;
+
+        return $confirm ?? false;
     }
 
     private function buildToolName(string $resourcePath, string $httpMethod, ToolAttribute|null $attribute): string

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -98,7 +98,11 @@ final readonly class SchemaConverter implements SchemaConverterInterface
             return $methodAttribute->confirm;
         }
 
-        return $classAttribute?->confirm ?? false;
+        if ($classAttribute === null) {
+            return false;
+        }
+
+        return $classAttribute->confirm;
     }
 
     private function buildToolName(string $resourcePath, string $httpMethod, ToolAttribute|null $attribute): string

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -94,15 +94,7 @@ final readonly class SchemaConverter implements SchemaConverterInterface
 
     private function resolveConfirm(ToolAttribute|null $classAttribute, ToolAttribute|null $methodAttribute): bool
     {
-        if ($methodAttribute !== null) {
-            return $methodAttribute->confirm;
-        }
-
-        if ($classAttribute === null) {
-            return false;
-        }
-
-        return $classAttribute->confirm;
+        return $methodAttribute?->confirm ?? $classAttribute?->confirm ?? false;
     }
 
     private function buildToolName(string $resourcePath, string $httpMethod, ToolAttribute|null $attribute): string

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -24,14 +24,20 @@ final readonly class Tool implements JsonSerializable
     ) {
     }
 
-    /** @return array{name: string, description: string, input_schema: InputSchema} */
+    /** @return array{name: string, description: string, input_schema: InputSchema, confirm?: true} */
     #[Override]
     public function jsonSerialize(): array
     {
-        return [
+        $data = [
             'name' => $this->name,
             'description' => $this->description,
             'input_schema' => $this->inputSchema,
         ];
+
+        if ($this->confirm) {
+            $data['confirm'] = true;
+        }
+
+        return $data;
     }
 }

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -11,7 +11,7 @@ use Override;
  * Tool definition for AI agent
  *
  * @psalm-type InputSchema = array{type: string, properties: array<string, mixed>, required?: list<string>}
- * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+ * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
  */
 final readonly class Tool implements JsonSerializable
 {

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -19,6 +19,7 @@ final readonly class Tool implements JsonSerializable
         public string $name,
         public string $description,
         public array $inputSchema,
+        public bool $confirm = false,
     ) {
     }
 

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -11,6 +11,7 @@ use Override;
  * Tool definition for AI agent
  *
  * @psalm-type InputSchema = array{type: string, properties: array<string, mixed>, required?: list<string>}
+ * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  */
 final readonly class Tool implements JsonSerializable
 {

--- a/tests/Fake/FakeConfirmationHandler.php
+++ b/tests/Fake/FakeConfirmationHandler.php
@@ -6,6 +6,7 @@ namespace BEAR\ToolUse\Fake;
 
 use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Runtime\ConfirmationHandlerInterface;
+use Override;
 
 /**
  * Fake confirmation handler for testing
@@ -22,6 +23,7 @@ final class FakeConfirmationHandler implements ConfirmationHandlerInterface
         $this->willConfirm = $willConfirm;
     }
 
+    #[Override]
     public function confirm(ToolCall $toolCall, string $llmText): bool
     {
         $this->calls[] = [

--- a/tests/Fake/FakeConfirmationHandler.php
+++ b/tests/Fake/FakeConfirmationHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Runtime\ConfirmationHandlerInterface;
+
+/**
+ * Fake confirmation handler for testing
+ */
+final class FakeConfirmationHandler implements ConfirmationHandlerInterface
+{
+    private bool $willConfirm = true;
+
+    /** @var list<array{toolCall: ToolCall, llmText: string}> */
+    public array $calls = [];
+
+    public function setWillConfirm(bool $willConfirm): void
+    {
+        $this->willConfirm = $willConfirm;
+    }
+
+    public function confirm(ToolCall $toolCall, string $llmText): bool
+    {
+        $this->calls[] = [
+            'toolCall' => $toolCall,
+            'llmText' => $llmText,
+        ];
+
+        return $this->willConfirm;
+    }
+}

--- a/tests/Fake/FakeLlmClient.php
+++ b/tests/Fake/FakeLlmClient.php
@@ -65,6 +65,28 @@ final class FakeLlmClient implements LlmClientInterface
     }
 
     /**
+     * Queue a tool use response with text
+     *
+     * @param array<string, mixed> $input
+     */
+    public function queueToolUseWithTextResponse(string $toolId, string $toolName, array $input, string $text): void
+    {
+        $this->responses[] = new LlmResponse(
+            stopReason: 'tool_use',
+            content: [
+                ['type' => 'text', 'text' => $text],
+                [
+                    'type' => 'tool_use',
+                    'id' => $toolId,
+                    'name' => $toolName,
+                    'input' => $input,
+                ],
+            ],
+            toolCalls: [new ToolCall($toolId, $toolName, $input)],
+        );
+    }
+
+    /**
      * Queue a max_tokens response
      */
     public function queueMaxTokensResponse(string $partialText): void
@@ -113,7 +135,7 @@ final class FakeLlmClient implements LlmClientInterface
     public function reset(): void
     {
         $this->responses = [];
-        $this->calls = [];
+        $this->calls     = [];
         $this->callIndex = 0;
     }
 }

--- a/tests/Fake/Resource/App/FakeConfirmInheritResource.php
+++ b/tests/Fake/Resource/App/FakeConfirmInheritResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+
+/**
+ * Class-level confirm: true with method-level #[Tool] that doesn't override confirm
+ */
+#[Tool(confirm: true)]
+class FakeConfirmInheritResource extends ResourceObject
+{
+    #[Tool(name: 'custom_get')]
+    public function onGet(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'GET'];
+
+        return $this;
+    }
+
+    public function onDelete(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'DELETE'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/Resource/App/FakeConfirmableResource.php
+++ b/tests/Fake/Resource/App/FakeConfirmableResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+
+#[Tool(confirm: true)]
+class FakeConfirmableResource extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'GET'];
+
+        return $this;
+    }
+
+    public function onDelete(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'DELETE'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/Resource/App/FakeMethodConfirmResource.php
+++ b/tests/Fake/Resource/App/FakeMethodConfirmResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+
+class FakeMethodConfirmResource extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'GET'];
+
+        return $this;
+    }
+
+    #[Tool(confirm: true)]
+    public function onDelete(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'DELETE'];
+
+        return $this;
+    }
+}

--- a/tests/Runtime/AgentConfirmationTest.php
+++ b/tests/Runtime/AgentConfirmationTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeConfirmationHandler;
+use BEAR\ToolUse\Fake\FakeLlmClient;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+#[CoversClass(Agent::class)]
+final class AgentConfirmationTest extends TestCase
+{
+    private FakeLlmClient $llmClient;
+    private FakeConfirmationHandler $confirmationHandler;
+    private Dispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->llmClient           = new FakeLlmClient();
+        $this->confirmationHandler = new FakeConfirmationHandler();
+
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('article_delete', 'app://self/article', 'delete');
+        $this->dispatcher = new Dispatcher($resource, $registry);
+    }
+
+    public function testConfirmationApproved(): void
+    {
+        $tools = [
+            new Tool('article_delete', 'Delete an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ], confirm: true),
+        ];
+
+        $agent = new Agent(
+            client: $this->llmClient,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+            confirmationHandler: $this->confirmationHandler,
+        );
+
+        $this->confirmationHandler->setWillConfirm(true);
+        $this->llmClient->queueToolUseWithTextResponse(
+            'call_1',
+            'article_delete',
+            ['id' => 123],
+            'I will delete article 123.',
+        );
+        $this->llmClient->queueTextResponse('Article 123 has been deleted.');
+
+        $response = $agent->run('Delete article 123');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Article 123 has been deleted.', $response->getText());
+        $this->assertCount(1, $this->confirmationHandler->calls);
+        $this->assertSame('article_delete', $this->confirmationHandler->calls[0]['toolCall']->name);
+        $this->assertSame('I will delete article 123.', $this->confirmationHandler->calls[0]['llmText']);
+    }
+
+    public function testConfirmationDenied(): void
+    {
+        $tools = [
+            new Tool('article_delete', 'Delete an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ], confirm: true),
+        ];
+
+        $agent = new Agent(
+            client: $this->llmClient,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+            confirmationHandler: $this->confirmationHandler,
+        );
+
+        $this->confirmationHandler->setWillConfirm(false);
+        $this->llmClient->queueToolUseWithTextResponse(
+            'call_1',
+            'article_delete',
+            ['id' => 123],
+            'I will delete article 123.',
+        );
+        $this->llmClient->queueTextResponse('Understood, I will not delete the article.');
+
+        $response = $agent->run('Delete article 123');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Understood, I will not delete the article.', $response->getText());
+
+        // Verify the LLM received the cancellation error
+        $secondCallMessages = $this->llmClient->calls[1]['messages'];
+        $toolResultMessage  = $secondCallMessages[2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('User cancelled this operation.', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testNonConfirmableToolExecutedWithoutConfirmation(): void
+    {
+        $tools = [
+            new Tool('article_get', 'Get an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ]),
+            new Tool('article_delete', 'Delete an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ], confirm: true),
+        ];
+
+        $agent = new Agent(
+            client: $this->llmClient,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+            confirmationHandler: $this->confirmationHandler,
+        );
+
+        // article_get has confirm: false, should not trigger confirmation
+        $this->llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+        $this->llmClient->queueTextResponse('Here is the article.');
+
+        $response = $agent->run('Get article 1');
+
+        $this->assertTrue($response->completed);
+        $this->assertEmpty($this->confirmationHandler->calls);
+    }
+
+    public function testConfirmableToolWithoutHandlerExecutesNormally(): void
+    {
+        $tools = [
+            new Tool('article_delete', 'Delete an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ], confirm: true),
+        ];
+
+        // No confirmation handler → tool executes without confirmation
+        $agent = new Agent(
+            client: $this->llmClient,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+
+        $this->llmClient->queueToolUseResponse('call_1', 'article_delete', ['id' => 1]);
+        $this->llmClient->queueTextResponse('Deleted.');
+
+        $response = $agent->run('Delete article 1');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Deleted.', $response->getText());
+    }
+
+    public function testConfirmationWithToolUseWithoutText(): void
+    {
+        $tools = [
+            new Tool('article_delete', 'Delete an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ], confirm: true),
+        ];
+
+        $agent = new Agent(
+            client: $this->llmClient,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+            confirmationHandler: $this->confirmationHandler,
+        );
+
+        // tool_use response without text block
+        $this->llmClient->queueToolUseResponse('call_1', 'article_delete', ['id' => 1]);
+        $this->llmClient->queueTextResponse('Done.');
+
+        $response = $agent->run('Delete article 1');
+
+        $this->assertTrue($response->completed);
+        // Handler receives empty text when no text block exists
+        $this->assertSame('', $this->confirmationHandler->calls[0]['llmText']);
+    }
+}

--- a/tests/Runtime/AgentFactoryTest.php
+++ b/tests/Runtime/AgentFactoryTest.php
@@ -9,6 +9,7 @@ use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeConfirmationHandler;
 use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Schema\SchemaConverter;
 use BEAR\ToolUse\Schema\ToolCollector;
@@ -94,5 +95,31 @@ final class AgentFactoryTest extends TestCase
 
         $tools = $this->factory->getTools();
         $this->assertCount(2, $tools);
+    }
+
+    public function testCreateAgentWithConfirmationHandler(): void
+    {
+        $confirmationHandler = new FakeConfirmationHandler();
+        $injector            = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource            = $injector->getInstance(ResourceInterface::class);
+        $resourceFactory     = $injector->getInstance(FactoryInterface::class);
+
+        $registry  = new ToolRegistry();
+        $converter = new SchemaConverter(DocBlockFactory::createInstance());
+        $collector = new ToolCollector($converter, $registry, $resourceFactory);
+        $dispatcher = new Dispatcher($resource, $registry);
+
+        $factory = new AgentFactory($this->llmClient, $dispatcher, $collector, $registry, $confirmationHandler);
+        $factory->addResources(['app://self/article']);
+
+        $this->llmClient->queueToolUseWithTextResponse('call_1', 'article_get', ['id' => 1], 'Getting article 1.');
+        $this->llmClient->queueTextResponse('Done.');
+
+        $agent    = $factory->create('You are a helpful assistant.');
+        $response = $agent->run('Get article 1');
+
+        $this->assertTrue($response->completed);
+        // article_get has confirm: false, so handler should NOT be called
+        $this->assertEmpty($confirmationHandler->calls);
     }
 }

--- a/tests/Schema/SchemaConverterConfirmTest.php
+++ b/tests/Schema/SchemaConverterConfirmTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Schema;
+
+use BEAR\ToolUse\Fake\Resource\App\FakeArticleResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeConfirmableResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeMethodConfirmResource;
+use phpDocumentor\Reflection\DocBlockFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function array_search;
+use function json_decode;
+use function json_encode;
+
+#[CoversClass(SchemaConverter::class)]
+final class SchemaConverterConfirmTest extends TestCase
+{
+    private SchemaConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new SchemaConverter(DocBlockFactory::createInstance());
+    }
+
+    public function testClassLevelConfirm(): void
+    {
+        $tools = $this->converter->convert(FakeConfirmableResource::class, '/confirmable');
+
+        $this->assertCount(2, $tools);
+        foreach ($tools as $tool) {
+            $this->assertTrue($tool->confirm);
+        }
+    }
+
+    public function testMethodLevelConfirm(): void
+    {
+        $tools = $this->converter->convert(FakeMethodConfirmResource::class, '/method-confirm');
+
+        $toolNames = array_map(static fn (Tool $t) => $t->name, $tools);
+
+        $getIndex = array_search('method_confirm_get', $toolNames, true);
+        $deleteIndex = array_search('method_confirm_delete', $toolNames, true);
+
+        // onGet has no confirm attribute → false
+        $this->assertFalse($tools[$getIndex]->confirm);
+        // onDelete has #[Tool(confirm: true)] → true
+        $this->assertTrue($tools[$deleteIndex]->confirm);
+    }
+
+    public function testDefaultConfirmIsFalse(): void
+    {
+        $tools = $this->converter->convert(FakeArticleResource::class, '/article');
+
+        $this->assertCount(1, $tools);
+        $this->assertFalse($tools[0]->confirm);
+    }
+
+    public function testConfirmNotSerializedToJson(): void
+    {
+        $tools = $this->converter->convert(FakeConfirmableResource::class, '/confirmable');
+
+        $json = json_encode($tools[0]);
+        $decoded = json_decode((string) $json, true);
+
+        $this->assertArrayHasKey('name', $decoded);
+        $this->assertArrayHasKey('description', $decoded);
+        $this->assertArrayHasKey('input_schema', $decoded);
+        $this->assertArrayNotHasKey('confirm', $decoded);
+    }
+}

--- a/tests/Schema/SchemaConverterConfirmTest.php
+++ b/tests/Schema/SchemaConverterConfirmTest.php
@@ -59,16 +59,23 @@ final class SchemaConverterConfirmTest extends TestCase
         $this->assertFalse($tools[0]->confirm);
     }
 
-    public function testConfirmNotSerializedToJson(): void
+    public function testConfirmTrueSerializedToJson(): void
     {
         $tools = $this->converter->convert(FakeConfirmableResource::class, '/confirmable');
 
-        $json = json_encode($tools[0]);
+        $json    = json_encode($tools[0]);
         $decoded = json_decode((string) $json, true);
 
-        $this->assertArrayHasKey('name', $decoded);
-        $this->assertArrayHasKey('description', $decoded);
-        $this->assertArrayHasKey('input_schema', $decoded);
+        $this->assertTrue($decoded['confirm']);
+    }
+
+    public function testConfirmFalseOmittedFromJson(): void
+    {
+        $tools = $this->converter->convert(FakeArticleResource::class, '/article');
+
+        $json    = json_encode($tools[0]);
+        $decoded = json_decode((string) $json, true);
+
         $this->assertArrayNotHasKey('confirm', $decoded);
     }
 }

--- a/tests/Schema/SchemaConverterConfirmTest.php
+++ b/tests/Schema/SchemaConverterConfirmTest.php
@@ -6,6 +6,7 @@ namespace BEAR\ToolUse\Schema;
 
 use BEAR\ToolUse\Fake\Resource\App\FakeArticleResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeConfirmableResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeConfirmInheritResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeMethodConfirmResource;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -45,6 +46,9 @@ final class SchemaConverterConfirmTest extends TestCase
         $getIndex = array_search('method_confirm_get', $toolNames, true);
         $deleteIndex = array_search('method_confirm_delete', $toolNames, true);
 
+        $this->assertNotFalse($getIndex);
+        $this->assertNotFalse($deleteIndex);
+
         // onGet has no confirm attribute → false
         $this->assertFalse($tools[$getIndex]->confirm);
         // onDelete has #[Tool(confirm: true)] → true
@@ -67,6 +71,24 @@ final class SchemaConverterConfirmTest extends TestCase
         $decoded = json_decode((string) $json, true);
 
         $this->assertTrue($decoded['confirm']);
+    }
+
+    public function testMethodAttributeWithoutConfirmInheritsClassConfirm(): void
+    {
+        $tools = $this->converter->convert(FakeConfirmInheritResource::class, '/confirm-inherit');
+
+        $toolNames = array_map(static fn (Tool $t) => $t->name, $tools);
+
+        $customGetIndex = array_search('custom_get', $toolNames, true);
+        $deleteIndex = array_search('confirm_inherit_delete', $toolNames, true);
+
+        $this->assertNotFalse($customGetIndex);
+        $this->assertNotFalse($deleteIndex);
+
+        // Method #[Tool(name: 'custom_get')] without confirm → inherits class confirm: true
+        $this->assertTrue($tools[$customGetIndex]->confirm);
+        // No method attribute → inherits class confirm: true
+        $this->assertTrue($tools[$deleteIndex]->confirm);
     }
 
     public function testConfirmFalseOmittedFromJson(): void

--- a/tests/Schema/ToolTest.php
+++ b/tests/Schema/ToolTest.php
@@ -48,5 +48,26 @@ final class ToolTest extends TestCase
         $this->assertSame('article_get', $json['name']);
         $this->assertSame('Get an article by ID', $json['description']);
         $this->assertSame('object', $json['input_schema']['type']);
+        $this->assertArrayNotHasKey('confirm', $json);
+    }
+
+    public function testJsonSerializeWithConfirm(): void
+    {
+        $tool = new Tool(
+            name: 'article_delete',
+            description: 'Delete an article by ID',
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [
+                    'id' => ['type' => 'integer'],
+                ],
+                'required' => ['id'],
+            ],
+            confirm: true,
+        );
+
+        $json = $tool->jsonSerialize();
+
+        $this->assertTrue($json['confirm']);
     }
 }


### PR DESCRIPTION
Add #[Tool(confirm: true)] attribute to require user confirmation before executing tool calls. The LLM's text response serves as the confirmation message, allowing context-aware prompts without templates.

- Add `confirm` parameter to #[Tool] attribute (class and method level)
- Add `confirm` property to Schema\Tool (excluded from JSON serialization)
- Create ConfirmationHandlerInterface for user-implemented confirmation
- Update Agent to intercept confirmable tool calls and delegate to handler
- Update AgentFactory to pass optional ConfirmationHandler
- Cancelled operations return error with "User cancelled this operation."

https://claude.ai/code/session_014iQ75LqBQMC1aDhDdQYX2c