### PR TITLE
Change description resolve priority to PHPDoc > ALPS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ src/
 │   ├── Agent.php        # Agent loop
 │   ├── AgentFactory.php # Agent builder
 │   ├── AgentResponse.php
+│   ├── ConfirmationHandlerInterface.php # User confirmation
 │   └── Message.php
 ├── Llm/                 # LLM related
 │   ├── LlmClientInterface.php  # User implementation
@@ -67,7 +68,8 @@ composer tests    # cs + sa + test
 ### BEAR.Sunday Integration
 
 - Expose resource classes as tools via full URI (`app://self/user`, `page://self/article`)
-- `#[Tool]` attribute for metadata customization (name, description)
+- `#[Tool]` attribute for metadata customization (name, description, confirm)
+- `#[Tool(confirm: true)]` requires user confirmation before tool execution
 - `#[Exclude]` attribute to exclude methods/classes from tool exposure (opt-out)
 - Supports BEAR\Resource\Annotation\JsonSchema for parameter validation
 
@@ -85,8 +87,10 @@ composer tests    # cs + sa + test
 
 ## Testing
 
+- 100% code coverage is mandatory
 - Fake implementations in `tests/Fake/`
 - `FakeLlmClient` simulates LLM responses
+- `FakeConfirmationHandler` simulates user confirmation
 - Fake resource classes in `tests/Fake/Resource/App/`
 
 ## Key Type Definitions
@@ -116,9 +120,11 @@ Error results are sent back to the LLM as `tool_result` messages with `is_error:
 
 ### Parameter Description Resolution Priority
 
-1. JSON Schema (`#[JsonSchema(params: '...')]` from BEAR.Resource)
-2. ALPS dictionary (`koriym/app-state-diagram` Profile API)
-3. PHPDoc `@param` via reflection
+1. JSON Schema (`#[JsonSchema(params: '...')]` from BEAR.Resource) — resolved in `SchemaConverter::mergeJsonSchemaProperties()`
+2. PHPDoc `@param` via reflection — resolved in `ParameterDescriptionResolver::resolve()`
+3. ALPS dictionary (`koriym/app-state-diagram` Profile API) — resolved in `ParameterDescriptionResolver::resolve()`
+
+JSON Schema descriptions (with constraints like enum, format, min/max) are handled by `SchemaConverter` before calling the resolver. The resolver handles only PHPDoc (method-specific) and ALPS (application-wide fallback).
 
 ### JSON Schema Integration
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -277,9 +277,9 @@ ALPSプロファイルの`semantic`記述子から`title`または`doc.value`が
 
 複数のソースが説明を提供する場合、以下の順序で解決されます：
 
-1. **JSON Schema** - スキーマファイルの`description`プロパティ
-2. **ALPS** - セマンティック記述子の`title`または`doc.value`
-3. **PHPDoc** - `@param`タグの説明
+1. **JSON Schema** - スキーマファイルの`description`プロパティ（+ `enum`、`format`、`min/max`等の制約）
+2. **PHPDoc** - `@param`タグの説明（メソッド固有）
+3. **ALPS** - セマンティック記述子の`title`または`doc.value`（アプリケーション全体のフォールバック）
 
 ## アーキテクチャ
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ The `title` or `doc.value` from ALPS `semantic` descriptors will be used as para
 
 When multiple sources provide descriptions, they are resolved in this order:
 
-1. **JSON Schema** - `description` property from schema file
-2. **ALPS** - `title` or `doc.value` from semantic descriptor
-3. **PHPDoc** - `@param` tag description
+1. **JSON Schema** - `description` property from schema file (+ constraints like `enum`, `format`, `min/max`)
+2. **PHPDoc** - `@param` tag description (method-specific)
+3. **ALPS** - `title` or `doc.value` from semantic descriptor (application-wide fallback)
 
 ## Architecture
 

--- a/src/Schema/ParameterDescriptionResolver.php
+++ b/src/Schema/ParameterDescriptionResolver.php
@@ -10,14 +10,12 @@ use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use ReflectionMethod;
 use ReflectionParameter;
 
-use function is_array;
-use function is_string;
 use function lcfirst;
 use function str_replace;
 use function ucwords;
 
 /**
- * Resolves parameter descriptions from JSON Schema, ALPS, or PHPDoc
+ * Resolves parameter descriptions from PHPDoc or ALPS
  */
 final readonly class ParameterDescriptionResolver implements ParameterDescriptionResolverInterface
 {
@@ -29,39 +27,18 @@ final readonly class ParameterDescriptionResolver implements ParameterDescriptio
     }
 
     #[Override]
-    public function resolve(ReflectionParameter $param, array|null $jsonSchema): string|null
+    public function resolve(ReflectionParameter $param): string|null
     {
         $paramName = $param->getName();
 
-        // 1. JSON Schema (highest priority)
-        $jsonSchemaDescription = $this->getJsonSchemaDescription($paramName, $jsonSchema);
-        if ($jsonSchemaDescription !== null) {
-            return $jsonSchemaDescription;
+        // 1. PHPDoc (highest priority - method-specific)
+        $phpDocDescription = $this->getPhpDocDescription($param, $paramName);
+        if ($phpDocDescription !== null) {
+            return $phpDocDescription;
         }
 
-        // 2. ALPS Dictionary
-        $alpsDescription = $this->getAlpsDictionaryDescription($paramName);
-        if ($alpsDescription !== null) {
-            return $alpsDescription;
-        }
-
-        // 3. PHPDoc (lowest priority)
-        return $this->getPhpDocDescription($param, $paramName);
-    }
-
-    /** @param array<string, mixed>|null $jsonSchema */
-    private function getJsonSchemaDescription(string $paramName, array|null $jsonSchema): string|null
-    {
-        if ($jsonSchema === null) {
-            return null;
-        }
-
-        $paramSchema = $jsonSchema[$paramName] ?? null;
-        if (! is_array($paramSchema) || ! isset($paramSchema['description']) || ! is_string($paramSchema['description'])) {
-            return null;
-        }
-
-        return $paramSchema['description'];
+        // 2. ALPS Dictionary (fallback - application-wide)
+        return $this->getAlpsDictionaryDescription($paramName);
     }
 
     private function getAlpsDictionaryDescription(string $paramName): string|null

--- a/src/Schema/ParameterDescriptionResolverInterface.php
+++ b/src/Schema/ParameterDescriptionResolverInterface.php
@@ -7,15 +7,14 @@ namespace BEAR\ToolUse\Schema;
 use ReflectionParameter;
 
 /**
- * Resolves parameter descriptions from various sources
+ * Resolves parameter descriptions from PHPDoc or ALPS
  */
 interface ParameterDescriptionResolverInterface
 {
     /**
      * Get description for a parameter
      *
-     * @param ReflectionParameter       $param      Parameter to get description for
-     * @param array<string, mixed>|null $jsonSchema JSON Schema properties
+     * @param ReflectionParameter $param Parameter to get description for
      */
-    public function resolve(ReflectionParameter $param, array|null $jsonSchema): string|null;
+    public function resolve(ReflectionParameter $param): string|null;
 }

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -171,7 +171,7 @@ final readonly class SchemaConverter implements SchemaConverterInterface
 
         // Add description if not already set by JSON Schema
         if (! isset($schema['description']) && $this->descriptionResolver !== null) {
-            $description = $this->descriptionResolver->resolve($param, $jsonSchema);
+            $description = $this->descriptionResolver->resolve($param);
             if ($description !== null) {
                 $schema['description'] = $description;
             }

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -4,6 +4,11 @@
     "version": "1.0",
     "descriptor": [
       {
+        "id": "id",
+        "type": "semantic",
+        "title": "Resource identifier"
+      },
+      {
         "id": "userId",
         "type": "semantic",
         "title": "User identifier"

--- a/tests/Schema/ParameterDescriptionResolverTest.php
+++ b/tests/Schema/ParameterDescriptionResolverTest.php
@@ -8,7 +8,6 @@ use BEAR\ToolUse\Fake\Resource\App\FakeDocParamResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeEmptyDocResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeJsonSchemaResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeMissingParamDocResource;
-use BEAR\ToolUse\Fake\Resource\App\FakeNoDescriptionResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeSnakeCaseResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeUserResource;
 use Koriym\AppStateDiagram\LabelNameTitle;
@@ -21,20 +20,18 @@ use ReflectionClass;
 #[CoversClass(ParameterDescriptionResolver::class)]
 final class ParameterDescriptionResolverTest extends TestCase
 {
-    public function testResolveFromJsonSchema(): void
+    public function testResolveFromPhpDoc(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
-        $jsonSchemaRepository = new JsonSchemaRepository(__DIR__ . '/../Fake/json_schema');
-        $resolver = new ParameterDescriptionResolver($docBlockFactory, $jsonSchemaRepository);
+        $resolver = new ParameterDescriptionResolver($docBlockFactory);
 
-        $reflection = new ReflectionClass(FakeJsonSchemaResource::class);
+        $reflection = new ReflectionClass(FakeDocParamResource::class);
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[0]; // id
 
-        $jsonSchema = $jsonSchemaRepository->getParameterSchema(FakeJsonSchemaResource::class, 'onGet');
-        $description = $resolver->resolve($param, $jsonSchema);
+        $description = $resolver->resolve($param);
 
-        $this->assertSame('User ID (1-1000)', $description);
+        $this->assertSame('The unique identifier', $description);
     }
 
     public function testResolveFromAlpsDictionary(): void
@@ -49,43 +46,28 @@ final class ParameterDescriptionResolverTest extends TestCase
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[0]; // userId
 
-        $description = $resolver->resolve($param, null);
+        $description = $resolver->resolve($param);
 
         $this->assertSame('User identifier', $description);
     }
 
-    public function testResolveFromPhpDoc(): void
-    {
-        $docBlockFactory = DocBlockFactory::createInstance();
-        $resolver = new ParameterDescriptionResolver($docBlockFactory);
-
-        $reflection = new ReflectionClass(FakeDocParamResource::class);
-        $method = $reflection->getMethod('onGet');
-        $param = $method->getParameters()[0]; // id
-
-        $description = $resolver->resolve($param, null);
-
-        $this->assertSame('The unique identifier', $description);
-    }
-
-    public function testJsonSchemaTakesPriorityOverAlps(): void
+    public function testPhpDocTakesPriorityOverAlps(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
         $profilePath = __DIR__ . '/../Fake/alps-profile.json';
         $profile = new Profile($profilePath, new LabelNameTitle());
         $dictionary = new AlpsSemanticDictionary($profile);
-        $jsonSchemaRepository = new JsonSchemaRepository(__DIR__ . '/../Fake/json_schema');
-        $resolver = new ParameterDescriptionResolver($docBlockFactory, $jsonSchemaRepository, $dictionary);
+        $resolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
 
-        $reflection = new ReflectionClass(FakeJsonSchemaResource::class);
+        // FakeDocParamResource has @param for "id", ALPS also has "id" descriptor
+        $reflection = new ReflectionClass(FakeDocParamResource::class);
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[0]; // id
 
-        $jsonSchema = $jsonSchemaRepository->getParameterSchema(FakeJsonSchemaResource::class, 'onGet');
-        $description = $resolver->resolve($param, $jsonSchema);
+        $description = $resolver->resolve($param);
 
-        // JSON Schema description should be used
-        $this->assertSame('User ID (1-1000)', $description);
+        // PHPDoc description should be used over ALPS
+        $this->assertSame('The unique identifier', $description);
     }
 
     public function testSnakeCaseToCamelCaseForAlps(): void
@@ -100,7 +82,7 @@ final class ParameterDescriptionResolverTest extends TestCase
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[0]; // user_id
 
-        $description = $resolver->resolve($param, null);
+        $description = $resolver->resolve($param);
 
         // user_id should be converted to userId for ALPS lookup
         $this->assertSame('User identifier', $description);
@@ -115,7 +97,7 @@ final class ParameterDescriptionResolverTest extends TestCase
         $method = $reflection->getMethod('onPost');
         $param = $method->getParameters()[1]; // email - no description
 
-        $description = $resolver->resolve($param, null);
+        $description = $resolver->resolve($param);
 
         $this->assertNull($description);
     }
@@ -151,7 +133,7 @@ final class ParameterDescriptionResolverTest extends TestCase
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[0]; // id with empty description
 
-        $description = $resolver->resolve($param, null);
+        $description = $resolver->resolve($param);
 
         $this->assertNull($description);
     }
@@ -165,7 +147,7 @@ final class ParameterDescriptionResolverTest extends TestCase
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[1]; // name (second parameter)
 
-        $description = $resolver->resolve($param, null);
+        $description = $resolver->resolve($param);
 
         // Should skip the first @param (id) and find the second one (name)
         $this->assertSame('The display name for this item', $description);
@@ -180,25 +162,26 @@ final class ParameterDescriptionResolverTest extends TestCase
         $method = $reflection->getMethod('onGet');
         $param = $method->getParameters()[1]; // name (not documented in PHPDoc)
 
-        $description = $resolver->resolve($param, null);
+        $description = $resolver->resolve($param);
 
         $this->assertNull($description);
     }
 
-    public function testReturnsNullWhenJsonSchemaHasNoDescription(): void
+    public function testFallsBackToAlpsWhenNoPhpDoc(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
-        $jsonSchemaRepository = new JsonSchemaRepository(__DIR__ . '/../Fake/json_schema');
-        $resolver = new ParameterDescriptionResolver($docBlockFactory, $jsonSchemaRepository);
+        $profilePath = __DIR__ . '/../Fake/alps-profile.json';
+        $profile = new Profile($profilePath, new LabelNameTitle());
+        $dictionary = new AlpsSemanticDictionary($profile);
+        $resolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
 
-        $reflection = new ReflectionClass(FakeNoDescriptionResource::class);
+        // FakeUserResource::onGet has no PHPDoc, so should fall back to ALPS
+        $reflection = new ReflectionClass(FakeUserResource::class);
         $method = $reflection->getMethod('onGet');
-        $param = $method->getParameters()[0]; // id (has schema but no description)
+        $param = $method->getParameters()[0]; // userId
 
-        $jsonSchema = $jsonSchemaRepository->getParameterSchema(FakeNoDescriptionResource::class, 'onGet');
-        $description = $resolver->resolve($param, $jsonSchema);
+        $description = $resolver->resolve($param);
 
-        // Should return null because JSON Schema property has no description
-        $this->assertNull($description);
+        $this->assertSame('User identifier', $description);
     }
 }


### PR DESCRIPTION
## Summary

- Remove redundant JSON Schema description resolution from `ParameterDescriptionResolver::resolve()` (already handled by `SchemaConverter::mergeJsonSchemaProperties()`)
- Change resolve priority from JSON Schema > ALPS > PHPDoc to **PHPDoc > ALPS**
- Remove `$jsonSchema` parameter from `ParameterDescriptionResolverInterface::resolve()`

### Final priority order (per parameter)

| Priority | Source | Handler | Scope |
|----------|--------|---------|-------|
| 1 | JSON Schema | `SchemaConverter::mergeJsonSchemaProperties()` | Method-specific + constraints |
| 2 | PHPDoc | `ParameterDescriptionResolver::resolve()` | Method-specific |
| 3 | ALPS | `ParameterDescriptionResolver::resolve()` | Application-wide fallback |

## Test plan

- [x] PHPDoc description takes priority over ALPS when both exist
- [x] Falls back to ALPS when no PHPDoc exists
- [x] JSON Schema description still takes highest priority (via SchemaConverter)
- [x] Full test suite passes (cs + sa + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)