### PR TITLE
Widen dependency version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "php": "^8.2",
         "bear/resource": "^1.10",
-        "koriym/app-state-diagram": "^0.17",
-        "phpdocumentor/reflection-docblock": "^6.0",
+        "koriym/app-state-diagram": "^0.8 || ^0.17",
+        "phpdocumentor/reflection-docblock": "^5.2 || ^6.0",
         "ray/di": "^2.18"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "phpunit/phpunit": "^11.0"
     },
     "autoload": {
+        "files": [
+            "src-polyfill/Override.php"
+        ],
         "psr-4": {
             "BEAR\\ToolUse\\": "src/"
         }

--- a/src-polyfill/Override.php
+++ b/src-polyfill/Override.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+if (!class_exists('Override', false)) {
+    #[\Attribute(\Attribute::TARGET_METHOD)]
+    final class Override {}
+}

--- a/src/Schema/AlpsSemanticDictionary.php
+++ b/src/Schema/AlpsSemanticDictionary.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Schema;
 use ArrayObject;
 use Koriym\AppStateDiagram\Profile;
 use Koriym\AppStateDiagram\SemanticDescriptor;
+use stdClass;
 
 use function is_string;
 
@@ -42,9 +43,13 @@ final class AlpsSemanticDictionary extends ArrayObject
             return $descriptor->title;
         }
 
-        // koriym/app-state-diagram extracts doc.value and stores it as a string
+        // v0.17+ stores doc as string, v0.8 stores as stdClass with value property
         if (is_string($descriptor->doc) && $descriptor->doc !== '') {
             return $descriptor->doc;
+        }
+
+        if ($descriptor->doc instanceof stdClass && isset($descriptor->doc->value)) {
+            return (string) $descriptor->doc->value;
         }
 
         return null;


### PR DESCRIPTION
## Summary

- Widen `koriym/app-state-diagram` from `^0.17` to `^0.8 || ^0.17`
- Widen `phpdocumentor/reflection-docblock` from `^6.0` to `^5.2 || ^6.0`
- Add `#[Override]` polyfill for PHP 8.2 compatibility
- Support `stdClass` doc property format in `AlpsSemanticDictionary` for v0.8 compatibility

This allows projects that depend on older versions of these packages to use BEAR.ToolUse without version conflicts.

### Compatibility verification

- **phpdocumentor/reflection-docblock v5.2**: All 6 APIs used (`createInstance()`, `create()`, `getSummary()`, `getTagsByName()`, `getVariableName()`, `getDescription()`) exist with identical signatures.
- **koriym/app-state-diagram v0.8**: `SemanticDescriptor` has `$id`, `$title`, `$doc` properties. The `$doc` type differs (`stdClass|null` in v0.8 vs `string|null` in v0.17), and `AlpsSemanticDictionary::extractDescription()` handles both formats — `is_string()` check for v0.17+ and `instanceof stdClass` fallback for v0.8.
- **PHP 8.2**: `src-polyfill/Override.php` provides the `#[Override]` attribute class (introduced in PHP 8.3) via `class_exists` guard, preventing `Attribute class "Override" not found` errors in older dependency versions.

## Test plan

- [x] `composer tests` — CS, SA, 134 tests all pass
- [x] CI passes on PHP 8.2/8.3/8.4/8.5 with `--prefer-lowest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)