### PR TITLE
feat: Add Tool filter for response filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,14 @@ A library that enables AI agent capabilities for BEAR.Sunday applications. Autom
 ```
 src/
 ├── Attribute/           # PHP Attributes
-│   ├── Tool.php         # Tool metadata (name, description, confirm)
+│   ├── Tool.php         # Tool metadata (name, description, confirm, filter)
 │   └── Exclude.php      # Exclude from tool exposure
 ├── Dispatch/            # Tool execution
 │   ├── DispatcherInterface.php
 │   ├── Dispatcher.php   # Dispatch to BEAR.Resource
 │   ├── ToolRegistryInterface.php
 │   ├── ToolRegistry.php # Tool name → resource mapping
+│   ├── ToolResultFilterInterface.php # Response filter
 │   ├── ToolCall.php     # Call from LLM
 │   └── ToolResult.php   # Execution result
 ├── Schema/              # Schema conversion
@@ -68,8 +69,9 @@ composer tests    # cs + sa + test
 ### BEAR.Sunday Integration
 
 - Expose resource classes as tools via full URI (`app://self/user`, `page://self/article`)
-- `#[Tool]` attribute for metadata customization (name, description, confirm)
+- `#[Tool]` attribute for metadata customization (name, description, confirm, filter)
 - `#[Tool(confirm: true)]` requires user confirmation before tool execution
+- `#[Tool(filter: FilterClass::class)]` filters response body before sending to LLM
 - `#[Exclude]` attribute to exclude methods/classes from tool exposure (opt-out)
 - Supports BEAR\Resource\Annotation\JsonSchema for parameter validation
 
@@ -97,7 +99,7 @@ composer tests    # cs + sa + test
 
 ```php
 // Tool mapping
-@psalm-type ToolMapping = array{resourceUri: string, method: string}
+@psalm-type ToolMapping = array{resourceUri: string, method: string, filter?: class-string<ToolResultFilterInterface>}
 
 // Message content
 @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
@@ -134,6 +136,26 @@ The agent supports user confirmation before executing destructive tool calls.
 - LLM's text response serves as the confirmation message (no templates needed)
 - If no handler is bound, confirmable tools execute normally (no blocking)
 - The `confirm` property is serialized to JSON only when `true` (omitted when `false`)
+
+## Response Filtering
+
+Filter tool response bodies before sending to LLM to reduce token usage.
+
+### How it works
+
+1. `#[Tool(filter: FilterClass::class)]` specifies a filter (class or method level)
+2. `SchemaConverter::resolveFilter()` reads filter class (explicit method filter takes priority, unset falls back to class)
+3. `Schema\Tool::$filter` stores the class-string (excluded from `jsonSerialize()`)
+4. `ToolCollector` passes `$filter` to `ToolRegistry::register()`
+5. `Dispatcher` applies filter on success responses only (errors are not filtered)
+
+### Key design decisions
+
+- Filter class implements `ToolResultFilterInterface` with `__invoke(mixed $body): mixed`
+- Filters are pure data transformers instantiated via `new` (no DI needed)
+- Filter exceptions are caught by the existing `Throwable` catch and fed back to LLM
+- The `filter` property is not serialized to JSON (internal use only)
+- `ToolMapping`'s `filter` key is optional (omitted when no filter is set)
 
 ## Notes
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -264,6 +264,54 @@ N → "User cancelled this operation." → LLM: 「承知しました。」
 
 `ConfirmationHandlerInterface` がバインドされていない場合、確認対象ツールも通常通り実行されます（ブロックなし）。
 
+## レスポンスフィルタリング
+
+`filter` を使用して、LLMに送信する前にレスポンスボディを削減できます。大量のデータを返すリソースでトークン効率を改善します。
+
+### フィルタの定義
+
+```php
+use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
+use Override;
+
+final readonly class SummaryFilter implements ToolResultFilterInterface
+{
+    #[Override]
+    public function __invoke(mixed $body): mixed
+    {
+        // LLMに必要なフィールドだけを抽出
+        return array_map(fn (array $item) => [
+            'id' => $item['id'],
+            'title' => $item['title'],
+        ], $body);
+    }
+}
+```
+
+### リソースへの適用
+
+```php
+use BEAR\ToolUse\Attribute\Tool;
+
+// クラスレベル - 全メソッドでフィルタを使用
+#[Tool(filter: SummaryFilter::class)]
+class Search extends ResourceObject
+{
+    public function onGet(string $query): static { /* ... */ }
+}
+
+// メソッドレベル - 特定のメソッドのみフィルタを使用
+class Article extends ResourceObject
+{
+    #[Tool(filter: SummaryFilter::class)]
+    public function onGet(string $query): static { /* ... */ }
+
+    public function onPost(string $title, string $body): static { /* ... */ }
+}
+```
+
+フィルタは成功レスポンスにのみ適用されます。エラーレスポンス（ステータスコード >= 400）はフィルタされずにそのまま送信されます。
+
 ## JSON Schemaの統合
 
 BEAR.ResourceのJSON Schemaを使用してパラメータ定義を強化できます。
@@ -409,6 +457,7 @@ Dispatcherが検出するエラー:
 | `SchemaConverterInterface` | リソースからツール定義への変換 |
 | `ToolCollectorInterface` | ツールの収集と登録 |
 | `AgentInterface` | エージェントランタイム |
+| `ToolResultFilterInterface` | LLM送信前のレスポンスフィルタ |
 | `ConfirmationHandlerInterface` | 破壊的ツールのユーザー確認 |
 
 ### 主要クラス

--- a/README.md
+++ b/README.md
@@ -264,6 +264,54 @@ N → "User cancelled this operation." → LLM: "Understood."
 
 If no `ConfirmationHandlerInterface` is bound, confirmable tools execute normally (no blocking).
 
+## Response Filtering
+
+Use `filter` to reduce the response body before sending to the LLM. This improves token efficiency for resources returning large payloads.
+
+### Define a Filter
+
+```php
+use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
+use Override;
+
+final readonly class SummaryFilter implements ToolResultFilterInterface
+{
+    #[Override]
+    public function __invoke(mixed $body): mixed
+    {
+        // Extract only the fields the LLM needs
+        return array_map(fn (array $item) => [
+            'id' => $item['id'],
+            'title' => $item['title'],
+        ], $body);
+    }
+}
+```
+
+### Apply to Resource
+
+```php
+use BEAR\ToolUse\Attribute\Tool;
+
+// Class level - all methods use the filter
+#[Tool(filter: SummaryFilter::class)]
+class Search extends ResourceObject
+{
+    public function onGet(string $query): static { /* ... */ }
+}
+
+// Method level - only specific methods use the filter
+class Article extends ResourceObject
+{
+    #[Tool(filter: SummaryFilter::class)]
+    public function onGet(string $query): static { /* ... */ }
+
+    public function onPost(string $title, string $body): static { /* ... */ }
+}
+```
+
+Filters are only applied to success responses. Error responses (status code >= 400) are sent unfiltered.
+
 ## JSON Schema Integration
 
 Use BEAR.Resource's JSON Schema for enhanced parameter definitions.
@@ -409,6 +457,7 @@ Errors detected by the Dispatcher:
 | `SchemaConverterInterface` | Converts resources to tool definitions |
 | `ToolCollectorInterface` | Collects and registers tools |
 | `AgentInterface` | Agent runtime |
+| `ToolResultFilterInterface` | Response filter before sending to LLM |
 | `ConfirmationHandlerInterface` | User confirmation for destructive tools |
 
 ### Main Classes

--- a/src/Attribute/Tool.php
+++ b/src/Attribute/Tool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ToolUse\Attribute;
 
 use Attribute;
+use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
 
 /**
  * Defines tool metadata for AI agents
@@ -19,6 +20,8 @@ final class Tool
         public string|null $name = null,
         public string|null $description = null,
         public bool|null $confirm = null,
+        /** @var class-string<ToolResultFilterInterface>|null */
+        public string|null $filter = null,
     ) {
     }
 }

--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -48,14 +48,25 @@ final readonly class Dispatcher implements DispatcherInterface
                 $toolCall->input,
             );
 
-            $content = json_encode($ro->body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-
             if ($ro->code >= self::ERROR_STATUS_THRESHOLD) {
+                $content = json_encode($ro->body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
                 return ToolResult::error(
                     $toolCall->id,
                     sprintf('%d: %s', $ro->code, $content),
                 );
             }
+
+            /** @var mixed $body */
+            $body = $ro->body;
+            if (isset($mapping['filter'])) {
+                /** @var class-string<ToolResultFilterInterface> $filterClass */
+                $filterClass = $mapping['filter'];
+                /** @var mixed $body */
+                $body = (new $filterClass())($body);
+            }
+
+            $content = json_encode($body, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
             return ToolResult::success($toolCall->id, $content);
         } catch (Throwable $e) {

--- a/src/Dispatch/ToolRegistry.php
+++ b/src/Dispatch/ToolRegistry.php
@@ -12,7 +12,7 @@ use function array_keys;
 /**
  * Registry for tool name to resource mapping
  *
- * @psalm-type ToolMapping = array{resourceUri: string, method: string}
+ * @psalm-type ToolMapping = array{resourceUri: string, method: string, filter?: class-string<ToolResultFilterInterface>}
  */
 final class ToolRegistry implements ToolRegistryInterface
 {
@@ -22,17 +22,24 @@ final class ToolRegistry implements ToolRegistryInterface
     /**
      * Register a tool mapping
      *
-     * @param string $toolName    Tool name (e.g., "article_get")
-     * @param string $resourceUri Resource URI without scheme (e.g., "article")
-     * @param string $method      HTTP method (e.g., "get")
+     * @param string                                       $toolName    Tool name (e.g., "article_get")
+     * @param string                                       $resourceUri Resource URI without scheme (e.g., "article")
+     * @param string                                       $method      HTTP method (e.g., "get")
+     * @param class-string<ToolResultFilterInterface>|null $filter      Filter class
      */
     #[Override]
-    public function register(string $toolName, string $resourceUri, string $method): void
+    public function register(string $toolName, string $resourceUri, string $method, string|null $filter = null): void
     {
-        $this->mappings[$toolName] = [
+        $mapping = [
             'resourceUri' => $resourceUri,
             'method' => $method,
         ];
+
+        if ($filter !== null) {
+            $mapping['filter'] = $filter;
+        }
+
+        $this->mappings[$toolName] = $mapping;
     }
 
     /**

--- a/src/Dispatch/ToolRegistryInterface.php
+++ b/src/Dispatch/ToolRegistryInterface.php
@@ -7,18 +7,19 @@ namespace BEAR\ToolUse\Dispatch;
 /**
  * Registry for tool name to resource mapping
  *
- * @psalm-type ToolMapping = array{resourceUri: string, method: string}
+ * @psalm-type ToolMapping = array{resourceUri: string, method: string, filter?: class-string<ToolResultFilterInterface>}
  */
 interface ToolRegistryInterface
 {
     /**
      * Register a tool mapping
      *
-     * @param string $toolName    Tool name (e.g., "article_get")
-     * @param string $resourceUri Resource URI (e.g., "app://self/article" or "article")
-     * @param string $method      HTTP method (e.g., "get")
+     * @param string                                       $toolName    Tool name (e.g., "article_get")
+     * @param string                                       $resourceUri Resource URI (e.g., "app://self/article" or "article")
+     * @param string                                       $method      HTTP method (e.g., "get")
+     * @param class-string<ToolResultFilterInterface>|null $filter      Filter class
      */
-    public function register(string $toolName, string $resourceUri, string $method): void;
+    public function register(string $toolName, string $resourceUri, string $method, string|null $filter = null): void;
 
     /**
      * Get mapping for a tool name

--- a/src/Dispatch/ToolResultFilterInterface.php
+++ b/src/Dispatch/ToolResultFilterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Dispatch;
+
+/**
+ * Filters tool result body before sending to LLM
+ */
+interface ToolResultFilterInterface
+{
+    public function __invoke(mixed $body): mixed;
+}

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -105,7 +105,10 @@ final readonly class SchemaConverter implements SchemaConverterInterface
     /** @return class-string<ToolResultFilterInterface>|null */
     private function resolveFilter(ToolAttribute|null $classAttribute, ToolAttribute|null $methodAttribute): string|null
     {
-        return $methodAttribute?->filter ?? $classAttribute?->filter;
+        $filter = $methodAttribute?->filter;
+        $filter ??= $classAttribute?->filter;
+
+        return $filter;
     }
 
     private function buildToolName(string $resourcePath, string $httpMethod, ToolAttribute|null $attribute): string

--- a/src/Schema/SchemaConverter.php
+++ b/src/Schema/SchemaConverter.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Schema;
 use BEAR\Resource\ResourceObject;
 use BEAR\ToolUse\Attribute\Exclude;
 use BEAR\ToolUse\Attribute\Tool as ToolAttribute;
+use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
 use Override;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use ReflectionClass;
@@ -83,13 +84,14 @@ final readonly class SchemaConverter implements SchemaConverterInterface
         $name = $this->buildToolName($resourcePath, $httpMethod, $methodAttribute);
         $description = $this->buildDescription($method, $classAttribute, $methodAttribute);
         $confirm = $this->resolveConfirm($classAttribute, $methodAttribute);
+        $filter = $this->resolveFilter($classAttribute, $methodAttribute);
 
         // Load JSON Schema for this method if available
         $jsonSchema = $this->jsonSchemaRepository?->getParameterSchema($resourceClass, $method->getName());
 
         $inputSchema = $this->buildInputSchema($method, $jsonSchema);
 
-        return new Tool($name, $description, $inputSchema, $confirm);
+        return new Tool($name, $description, $inputSchema, $confirm, $filter);
     }
 
     private function resolveConfirm(ToolAttribute|null $classAttribute, ToolAttribute|null $methodAttribute): bool
@@ -98,6 +100,12 @@ final readonly class SchemaConverter implements SchemaConverterInterface
         $confirm ??= $classAttribute?->confirm;
 
         return $confirm ?? false;
+    }
+
+    /** @return class-string<ToolResultFilterInterface>|null */
+    private function resolveFilter(ToolAttribute|null $classAttribute, ToolAttribute|null $methodAttribute): string|null
+    {
+        return $methodAttribute?->filter ?? $classAttribute?->filter;
     }
 
     private function buildToolName(string $resourcePath, string $httpMethod, ToolAttribute|null $attribute): string

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Schema;
 
+use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
 use JsonSerializable;
 use Override;
 
@@ -21,6 +22,8 @@ final readonly class Tool implements JsonSerializable
         public string $description,
         public array $inputSchema,
         public bool $confirm = false,
+        /** @var class-string<ToolResultFilterInterface>|null */
+        public string|null $filter = null,
     ) {
     }
 

--- a/src/Schema/ToolCollector.php
+++ b/src/Schema/ToolCollector.php
@@ -63,7 +63,7 @@ final readonly class ToolCollector implements ToolCollectorInterface
 
         foreach ($tools as $tool) {
             $method = $this->extractMethodFromToolName($tool->name, $resourcePath);
-            $this->registry->register($tool->name, $uri, $method);
+            $this->registry->register($tool->name, $uri, $method, $tool->filter);
         }
 
         return $tools;

--- a/tests/Dispatch/DispatcherTest.php
+++ b/tests/Dispatch/DispatcherTest.php
@@ -6,6 +6,7 @@ namespace BEAR\ToolUse\Dispatch;
 
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -199,5 +200,42 @@ final class DispatcherTest extends TestCase
         $result = $this->dispatcher->dispatch($toolCall);
 
         $this->assertFalse($result->isError);
+    }
+
+    public function testDispatchWithFilter(): void
+    {
+        $this->registry->register('filtered_get', 'app://self/filtered', 'get', FakeSummaryFilter::class);
+        $toolCall = new ToolCall('call_filter', 'filtered_get', ['id' => 1]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertFalse($result->isError);
+        $this->assertStringContainsString('"id":1', $result->content);
+        $this->assertStringContainsString('"title":"Article 1"', $result->content);
+        $this->assertStringNotContainsString('body', $result->content);
+        $this->assertStringNotContainsString('metadata', $result->content);
+    }
+
+    public function testDispatchWithFilterNotAppliedOnError(): void
+    {
+        $this->registry->register('status_error_get', 'app://self/status-error', 'get', FakeSummaryFilter::class);
+        $toolCall = new ToolCall('call_filter_error', 'status_error_get', ['code' => 400]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertTrue($result->isError);
+        $this->assertStringContainsString('400:', $result->content);
+    }
+
+    public function testDispatchWithoutFilter(): void
+    {
+        $this->registry->register('filtered_get', 'app://self/filtered', 'get');
+        $toolCall = new ToolCall('call_no_filter', 'filtered_get', ['id' => 1]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertFalse($result->isError);
+        // Without filter, body text should be present
+        $this->assertStringContainsString('Long body text', $result->content);
     }
 }

--- a/tests/Dispatch/ToolRegistryTest.php
+++ b/tests/Dispatch/ToolRegistryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Dispatch;
 
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -53,5 +54,27 @@ final class ToolRegistryTest extends TestCase
         $this->assertCount(2, $names);
         $this->assertContains('article_get', $names);
         $this->assertContains('user_post', $names);
+    }
+
+    public function testRegisterWithFilter(): void
+    {
+        $this->registry->register('search_get', 'search', 'get', FakeSummaryFilter::class);
+
+        $mapping = $this->registry->get('search_get');
+
+        $this->assertNotNull($mapping);
+        $this->assertSame('search', $mapping['resourceUri']);
+        $this->assertSame('get', $mapping['method']);
+        $this->assertSame(FakeSummaryFilter::class, $mapping['filter']);
+    }
+
+    public function testRegisterWithoutFilterOmitsKey(): void
+    {
+        $this->registry->register('article_get', 'article', 'get');
+
+        $mapping = $this->registry->get('article_get');
+
+        $this->assertNotNull($mapping);
+        $this->assertArrayNotHasKey('filter', $mapping);
     }
 }

--- a/tests/Fake/FakeSummaryFilter.php
+++ b/tests/Fake/FakeSummaryFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
+use Override;
+
+use function array_map;
+use function is_array;
+
+/**
+ * Extracts only id and title from result items
+ */
+final readonly class FakeSummaryFilter implements ToolResultFilterInterface
+{
+    /** @return list<array{id: mixed, title: mixed}>|mixed */
+    #[Override]
+    public function __invoke(mixed $body): mixed
+    {
+        if (! is_array($body)) {
+            return $body;
+        }
+
+        return array_map(static fn (array $item): array => [
+            'id' => $item['id'],
+            'title' => $item['title'],
+        ], $body);
+    }
+}

--- a/tests/Fake/Resource/App/FakeFilterInheritResource.php
+++ b/tests/Fake/Resource/App/FakeFilterInheritResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
+
+/**
+ * Class-level filter with method-level #[Tool] that doesn't override filter
+ */
+#[Tool(filter: FakeSummaryFilter::class)]
+class FakeFilterInheritResource extends ResourceObject
+{
+    #[Tool(name: 'custom_filtered_get')]
+    public function onGet(int $id): static
+    {
+        $this->body = [
+            ['id' => $id, 'title' => 'Article 1', 'body' => 'Long body text...'],
+        ];
+
+        return $this;
+    }
+
+    public function onDelete(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'DELETE'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/Resource/App/FakeFilteredResource.php
+++ b/tests/Fake/Resource/App/FakeFilteredResource.php
@@ -8,9 +8,9 @@ use BEAR\Resource\ResourceObject;
 use BEAR\ToolUse\Attribute\Tool;
 use BEAR\ToolUse\Fake\FakeSummaryFilter;
 
-#[Tool(filter: FakeSummaryFilter::class)]
 class FakeFilteredResource extends ResourceObject
 {
+    #[Tool(filter: FakeSummaryFilter::class)]
     public function onGet(int $id): static
     {
         $this->body = [

--- a/tests/Fake/Resource/App/FakeFilteredResource.php
+++ b/tests/Fake/Resource/App/FakeFilteredResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
+
+#[Tool(filter: FakeSummaryFilter::class)]
+class FakeFilteredResource extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        $this->body = [
+            ['id' => $id, 'title' => 'Article 1', 'body' => 'Long body text...', 'metadata' => ['views' => 100]],
+        ];
+
+        return $this;
+    }
+
+    public function onDelete(int $id): static
+    {
+        $this->body = ['id' => $id, 'method' => 'DELETE'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/Resource/App/FakeMethodFilterResource.php
+++ b/tests/Fake/Resource/App/FakeMethodFilterResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
+
+class FakeMethodFilterResource extends ResourceObject
+{
+    #[Tool(filter: FakeSummaryFilter::class)]
+    public function onGet(int $id): static
+    {
+        $this->body = [
+            ['id' => $id, 'title' => 'Article 1', 'body' => 'Long body text...'],
+        ];
+
+        return $this;
+    }
+
+    public function onPost(string $name): static
+    {
+        $this->body = ['name' => $name, 'method' => 'POST'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/Resource/App/Filtered.php
+++ b/tests/Fake/Resource/App/Filtered.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use BEAR\ToolUse\Attribute\Tool;
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
+
+#[Tool(filter: FakeSummaryFilter::class)]
+class Filtered extends ResourceObject
+{
+    public function onGet(int $id): static
+    {
+        $this->body = [
+            ['id' => $id, 'title' => 'Article 1', 'body' => 'Long body text...'],
+        ];
+
+        return $this;
+    }
+}

--- a/tests/Schema/SchemaConverterFilterTest.php
+++ b/tests/Schema/SchemaConverterFilterTest.php
@@ -9,6 +9,7 @@ use BEAR\ToolUse\Fake\Resource\App\FakeArticleResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeFilteredResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeFilterInheritResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeMethodFilterResource;
+use BEAR\ToolUse\Fake\Resource\App\Filtered;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -30,12 +31,10 @@ final class SchemaConverterFilterTest extends TestCase
 
     public function testClassLevelFilter(): void
     {
-        $tools = $this->converter->convert(FakeFilteredResource::class, '/filtered');
+        $tools = $this->converter->convert(Filtered::class, '/filtered');
 
-        $this->assertCount(2, $tools);
-        foreach ($tools as $tool) {
-            $this->assertSame(FakeSummaryFilter::class, $tool->filter);
-        }
+        $this->assertCount(1, $tools);
+        $this->assertSame(FakeSummaryFilter::class, $tools[0]->filter);
     }
 
     public function testMethodLevelFilter(): void

--- a/tests/Schema/SchemaConverterFilterTest.php
+++ b/tests/Schema/SchemaConverterFilterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Schema;
+
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
+use BEAR\ToolUse\Fake\Resource\App\FakeArticleResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeFilteredResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeFilterInheritResource;
+use BEAR\ToolUse\Fake\Resource\App\FakeMethodFilterResource;
+use phpDocumentor\Reflection\DocBlockFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function array_search;
+use function json_decode;
+use function json_encode;
+
+#[CoversClass(SchemaConverter::class)]
+final class SchemaConverterFilterTest extends TestCase
+{
+    private SchemaConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new SchemaConverter(DocBlockFactory::createInstance());
+    }
+
+    public function testClassLevelFilter(): void
+    {
+        $tools = $this->converter->convert(FakeFilteredResource::class, '/filtered');
+
+        $this->assertCount(2, $tools);
+        foreach ($tools as $tool) {
+            $this->assertSame(FakeSummaryFilter::class, $tool->filter);
+        }
+    }
+
+    public function testMethodLevelFilter(): void
+    {
+        $tools = $this->converter->convert(FakeMethodFilterResource::class, '/method-filter');
+
+        $toolNames = array_map(static fn (Tool $t) => $t->name, $tools);
+
+        $getIndex = array_search('method_filter_get', $toolNames, true);
+        $postIndex = array_search('method_filter_post', $toolNames, true);
+
+        $this->assertNotFalse($getIndex);
+        $this->assertNotFalse($postIndex);
+
+        // onGet has #[Tool(filter: ...)] → filter set
+        $this->assertSame(FakeSummaryFilter::class, $tools[$getIndex]->filter);
+        // onPost has no filter → null
+        $this->assertNull($tools[$postIndex]->filter);
+    }
+
+    public function testDefaultFilterIsNull(): void
+    {
+        $tools = $this->converter->convert(FakeArticleResource::class, '/article');
+
+        $this->assertCount(1, $tools);
+        $this->assertNull($tools[0]->filter);
+    }
+
+    public function testFilterNotSerializedToJson(): void
+    {
+        $tools = $this->converter->convert(FakeFilteredResource::class, '/filtered');
+
+        $json = json_encode($tools[0]);
+        $decoded = json_decode((string) $json, true);
+
+        $this->assertArrayNotHasKey('filter', $decoded);
+    }
+
+    public function testMethodAttributeWithoutFilterInheritsClassFilter(): void
+    {
+        $tools = $this->converter->convert(FakeFilterInheritResource::class, '/filter-inherit');
+
+        $toolNames = array_map(static fn (Tool $t) => $t->name, $tools);
+
+        $customGetIndex = array_search('custom_filtered_get', $toolNames, true);
+        $deleteIndex = array_search('filter_inherit_delete', $toolNames, true);
+
+        $this->assertNotFalse($customGetIndex);
+        $this->assertNotFalse($deleteIndex);
+
+        // Method #[Tool(name: 'custom_filtered_get')] without filter → inherits class filter
+        $this->assertSame(FakeSummaryFilter::class, $tools[$customGetIndex]->filter);
+        // No method attribute → inherits class filter
+        $this->assertSame(FakeSummaryFilter::class, $tools[$deleteIndex]->filter);
+    }
+}

--- a/tests/Schema/ToolCollectorTest.php
+++ b/tests/Schema/ToolCollectorTest.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Schema;
 use BEAR\Resource\FactoryInterface;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -113,5 +114,14 @@ final class ToolCollectorTest extends TestCase
         $mapping = $this->registry->get('article_get');
         $this->assertNotNull($mapping);
         $this->assertSame('page://self/article', $mapping['resourceUri']);
+    }
+
+    public function testFilterPropagatedToRegistry(): void
+    {
+        $this->collector->collect(['app://self/filtered']);
+
+        $mapping = $this->registry->get('filtered_get');
+        $this->assertNotNull($mapping);
+        $this->assertSame(FakeSummaryFilter::class, $mapping['filter']);
     }
 }

--- a/tests/Schema/ToolTest.php
+++ b/tests/Schema/ToolTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Schema;
 
+use BEAR\ToolUse\Fake\FakeSummaryFilter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -69,5 +70,54 @@ final class ToolTest extends TestCase
         $json = $tool->jsonSerialize();
 
         $this->assertTrue($json['confirm']);
+    }
+
+    public function testFilterProperty(): void
+    {
+        $tool = new Tool(
+            name: 'search_get',
+            description: 'Search articles',
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [],
+                'required' => [],
+            ],
+            filter: FakeSummaryFilter::class,
+        );
+
+        $this->assertSame(FakeSummaryFilter::class, $tool->filter);
+    }
+
+    public function testFilterNotIncludedInJsonSerialize(): void
+    {
+        $tool = new Tool(
+            name: 'search_get',
+            description: 'Search articles',
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [],
+                'required' => [],
+            ],
+            filter: FakeSummaryFilter::class,
+        );
+
+        $json = $tool->jsonSerialize();
+
+        $this->assertArrayNotHasKey('filter', $json);
+    }
+
+    public function testFilterDefaultIsNull(): void
+    {
+        $tool = new Tool(
+            name: 'article_get',
+            description: 'Get article',
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [],
+                'required' => [],
+            ],
+        );
+
+        $this->assertNull($tool->filter);
     }
 }


### PR DESCRIPTION
## Summary

- Add `#[Tool(filter: FilterClass::class)]` attribute for declarative tool response filtering
- Implement `ToolResultFilterInterface` to transform response body before sending to LLM
- Improve token efficiency for resources returning large payloads (e.g., CMS search results) by extracting only relevant fields

## Design

- Filter can be specified at class level or method level (method takes priority)
- Error responses (status code >= 400) are not filtered
- Filters are pure data transformers instantiated via `new` (no DI needed)
- `ToolMapping`'s `filter` key is optional (omitted when no filter is set)
- `Schema\Tool::$filter` is excluded from JSON serialization (internal use only)

## Data flow

```
#[Tool(filter: FilterClass::class)]
  → SchemaConverter::resolveFilter() [method > class > null]
    → Schema\Tool::$filter
      → ToolCollector → ToolRegistry (mapping with filter key)
        → Dispatcher: apply filter on success responses only
```

## Test plan

- [x] `SchemaConverterFilterTest`: class-level / method-level / inheritance / default null / JSON exclusion
- [x] `ToolTest`: filter property / jsonSerialize exclusion / default null
- [x] `ToolRegistryTest`: register with filter / key omission without filter
- [x] `ToolCollectorTest`: filter propagation
- [x] `DispatcherTest`: filter application / no filter on error / no filter when unset
- [x] `composer tests` all pass (CS + Psalm + PHPUnit 148 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)