### PR TITLE
feat: Add streaming agent for SSE real-time output

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: '8.3'
+      php_version: '8.4'

--- a/README.ja.md
+++ b/README.ja.md
@@ -156,6 +156,41 @@ $response = $agent->run('このユーザーについてもっと教えて');
 $agent->reset();
 ```
 
+### 6. ストリーミングエージェント
+
+リアルタイム出力（SSE、WebSocket）には、ストリーミングエージェントを使用します。LLMの出力に応じてイベントをyieldします。
+
+```php
+use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
+
+// DIモジュールでストリーミングクライアントをバインド
+$this->bind(StreamingLlmClientInterface::class)->to(MyStreamingLlmClient::class);
+```
+
+```php
+// ストリーミングエージェントを作成
+$agent = $factory
+    ->addResources(['app://self/user', 'app://self/article'])
+    ->createStreaming('あなたは親切なアシスタントです。');
+
+// イベントを処理
+foreach ($agent->runStream('ユーザー123を取得して') as $event) {
+    match ($event->type) {
+        'text_delta'  => sendSseEvent('text', $event->data['text']),
+        'tool_start'  => sendSseEvent('status', "{$event->data['toolName']}を呼び出し中..."),
+        'tool_result' => sendSseEvent('status', "{$event->data['toolName']}完了"),
+        'completed'   => sendSseEvent('done', $event->data['fullText']),
+        'error'       => sendSseEvent('error', $event->data['message']),
+    };
+}
+```
+
+`AgentEvent` は `JsonSerializable` を実装しており、SSEレスポンスで直接利用できます：
+
+```php
+echo "data: " . json_encode($event) . "\n\n";
+```
+
 ## ツール公開の制御
 
 ### メソッド単位での除外
@@ -452,11 +487,13 @@ Dispatcherが検出するエラー:
 | インターフェイス | 説明 |
 |-----------------|------|
 | `LlmClientInterface` | LLM APIクライアント（ユーザー実装） |
+| `StreamingLlmClientInterface` | ストリーミングLLM APIクライアント（ユーザー実装） |
 | `DispatcherInterface` | ツール呼び出しのディスパッチ |
 | `ToolRegistryInterface` | ツール名とリソースのマッピング |
 | `SchemaConverterInterface` | リソースからツール定義への変換 |
 | `ToolCollectorInterface` | ツールの収集と登録 |
 | `AgentInterface` | エージェントランタイム |
+| `StreamingAgentInterface` | ストリーミングエージェントランタイム |
 | `ToolResultFilterInterface` | LLM送信前のレスポンスフィルタ |
 | `ConfirmationHandlerInterface` | 破壊的ツールのユーザー確認 |
 
@@ -465,8 +502,11 @@ Dispatcherが検出するエラー:
 | クラス | 説明 |
 |-------|------|
 | `Agent` | LLMとの会話ループを管理 |
-| `AgentFactory` | エージェントのビルダー |
-| `AgentResponse` | エージェント実行結果 |
+| `StreamingAgent` | `AgentEvent`をyieldするストリーミング会話ループ |
+| `AgentFactory` | エージェントのビルダー（同期・ストリーミング） |
+| `AgentResponse` | エージェント実行結果（同期） |
+| `AgentEvent` | ストリーミングイベント（`JsonSerializable`） |
+| `StreamEvent` | 低レベルLLMストリームイベント |
 | `Tool` | ツール定義（JSON Schema） |
 | `ToolCall` | LLMからのツール呼び出し |
 | `ToolResult` | ツール実行結果 |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,41 @@ $response = $agent->run('Tell me more about this user');
 $agent->reset();
 ```
 
+### 6. Streaming Agent
+
+For real-time output (SSE, WebSocket), use the streaming agent. It yields events as the LLM generates output.
+
+```php
+use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
+
+// Bind streaming client in DI module
+$this->bind(StreamingLlmClientInterface::class)->to(MyStreamingLlmClient::class);
+```
+
+```php
+// Create streaming agent
+$agent = $factory
+    ->addResources(['app://self/user', 'app://self/article'])
+    ->createStreaming('You are a helpful assistant.');
+
+// Consume events
+foreach ($agent->runStream('Get user 123') as $event) {
+    match ($event->type) {
+        'text_delta'  => sendSseEvent('text', $event->data['text']),
+        'tool_start'  => sendSseEvent('status', "Calling {$event->data['toolName']}..."),
+        'tool_result' => sendSseEvent('status', "{$event->data['toolName']} done"),
+        'completed'   => sendSseEvent('done', $event->data['fullText']),
+        'error'       => sendSseEvent('error', $event->data['message']),
+    };
+}
+```
+
+`AgentEvent` implements `JsonSerializable` for direct use in SSE responses:
+
+```php
+echo "data: " . json_encode($event) . "\n\n";
+```
+
 ## Controlling Tool Exposure
 
 ### Exclude Specific Methods
@@ -452,11 +487,13 @@ Errors detected by the Dispatcher:
 | Interface | Description |
 |-----------|-------------|
 | `LlmClientInterface` | LLM API client (user implementation) |
+| `StreamingLlmClientInterface` | Streaming LLM API client (user implementation) |
 | `DispatcherInterface` | Dispatches tool calls |
 | `ToolRegistryInterface` | Maps tool names to resources |
 | `SchemaConverterInterface` | Converts resources to tool definitions |
 | `ToolCollectorInterface` | Collects and registers tools |
 | `AgentInterface` | Agent runtime |
+| `StreamingAgentInterface` | Streaming agent runtime |
 | `ToolResultFilterInterface` | Response filter before sending to LLM |
 | `ConfirmationHandlerInterface` | User confirmation for destructive tools |
 
@@ -465,8 +502,11 @@ Errors detected by the Dispatcher:
 | Class | Description |
 |-------|-------------|
 | `Agent` | Manages conversation loop with LLM |
-| `AgentFactory` | Builder for agents |
-| `AgentResponse` | Agent execution result |
+| `StreamingAgent` | Streaming conversation loop yielding `AgentEvent` |
+| `AgentFactory` | Builder for agents (sync and streaming) |
+| `AgentResponse` | Agent execution result (sync) |
+| `AgentEvent` | Streaming event (`JsonSerializable`) |
+| `StreamEvent` | Low-level LLM stream event |
 | `Tool` | Tool definition (JSON Schema) |
 | `ToolCall` | Tool call from LLM |
 | `ToolResult` | Tool execution result |

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    phpVersion="8.2"
+    phpVersion="8.3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor-bin/tools/vendor/vimeo/psalm/config.xsd"
@@ -25,9 +25,6 @@
         <PossiblyUnusedMethod errorLevel="suppress"/>
         <PossiblyUnusedProperty errorLevel="suppress"/>
         <PossiblyUnusedReturnValue errorLevel="suppress"/>
-
-        <!-- Override polyfill for PHP 8.2 target -->
-        <InvalidAttribute errorLevel="suppress"/>
 
         <!-- Mixed content for AgentResponse -->
         <MixedAssignment>

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,10 +26,14 @@
         <PossiblyUnusedProperty errorLevel="suppress"/>
         <PossiblyUnusedReturnValue errorLevel="suppress"/>
 
+        <!-- Override polyfill for PHP 8.2 target -->
+        <InvalidAttribute errorLevel="suppress"/>
+
         <!-- Mixed content for AgentResponse -->
         <MixedAssignment>
             <errorLevel type="suppress">
                 <file name="src/Runtime/AgentResponse.php"/>
+                <file name="src/Runtime/StreamingAgent.php"/>
             </errorLevel>
         </MixedAssignment>
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -33,7 +33,7 @@
         <MixedAssignment>
             <errorLevel type="suppress">
                 <file name="src/Runtime/AgentResponse.php"/>
-                <file name="src/Runtime/StreamingAgent.php"/>
+                <file name="src/Runtime/StreamContentAccumulator.php"/>
             </errorLevel>
         </MixedAssignment>
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,6 +26,9 @@
         <PossiblyUnusedProperty errorLevel="suppress"/>
         <PossiblyUnusedReturnValue errorLevel="suppress"/>
 
+        <!-- Psalm 6.x bug: #[Override] on interface implementations reported as "cannot be used on a function" -->
+        <InvalidAttribute errorLevel="suppress"/>
+
         <!-- Mixed content for AgentResponse -->
         <MixedAssignment>
             <errorLevel type="suppress">

--- a/src/Llm/StreamEvent.php
+++ b/src/Llm/StreamEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Llm;
+
+/**
+ * Low-level stream event from LLM
+ */
+final readonly class StreamEvent
+{
+    public const TEXT_DELTA = 'text_delta';
+    public const TOOL_USE_START = 'tool_use_start';
+    public const TOOL_USE_DELTA = 'tool_use_delta';
+    public const CONTENT_BLOCK_STOP = 'content_block_stop';
+    public const MESSAGE_STOP = 'message_stop';
+
+    /** @param array<string, mixed> $data */
+    public function __construct(
+        public string $type,
+        public array $data = [],
+    ) {
+    }
+}

--- a/src/Llm/StreamingLlmClientInterface.php
+++ b/src/Llm/StreamingLlmClientInterface.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Llm;
 
-use Generator;
 use BEAR\ToolUse\Runtime\Message;
 use BEAR\ToolUse\Schema\Tool;
+use Generator;
 
 /**
  * Interface for streaming LLM API clients
  *
- * @psalm-type StreamGenerator = Generator<int, StreamEvent, void>
+ * @psalm-type StreamGenerator = Generator<int, StreamEvent, mixed, void>
  */
 interface StreamingLlmClientInterface
 {
@@ -21,7 +21,7 @@ interface StreamingLlmClientInterface
      * @param list<Message> $messages
      * @param list<Tool>    $tools
      *
-     * @return Generator<int, StreamEvent, void>
+     * @return Generator<int, StreamEvent, mixed, void>
      */
     public function chatStream(
         string $system,

--- a/src/Llm/StreamingLlmClientInterface.php
+++ b/src/Llm/StreamingLlmClientInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Llm;
+
+use Generator;
+use BEAR\ToolUse\Runtime\Message;
+use BEAR\ToolUse\Schema\Tool;
+
+/**
+ * Interface for streaming LLM API clients
+ *
+ * @psalm-type StreamGenerator = Generator<int, StreamEvent, void>
+ */
+interface StreamingLlmClientInterface
+{
+    /**
+     * Send a streaming chat request to the LLM
+     *
+     * @param list<Message> $messages
+     * @param list<Tool>    $tools
+     *
+     * @return Generator<int, StreamEvent, void>
+     */
+    public function chatStream(
+        string $system,
+        array $messages,
+        array $tools,
+    ): Generator;
+}

--- a/src/Runtime/AgentEvent.php
+++ b/src/Runtime/AgentEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use JsonSerializable;
+use Override;
+
+/**
+ * High-level agent event for application consumption
+ */
+final readonly class AgentEvent implements JsonSerializable
+{
+    public const TEXT_DELTA = 'text_delta';
+    public const TOOL_START = 'tool_start';
+    public const TOOL_RESULT = 'tool_result';
+    public const COMPLETED = 'completed';
+    public const ERROR = 'error';
+
+    /** @param array<string, mixed> $data */
+    private function __construct(
+        public string $type,
+        public array $data = [],
+    ) {
+    }
+
+    public static function textDelta(string $text): self
+    {
+        return new self(self::TEXT_DELTA, ['text' => $text]);
+    }
+
+    public static function toolStart(string $toolName): self
+    {
+        return new self(self::TOOL_START, ['toolName' => $toolName]);
+    }
+
+    public static function toolResult(string $toolName): self
+    {
+        return new self(self::TOOL_RESULT, ['toolName' => $toolName]);
+    }
+
+    public static function completed(string $fullText): self
+    {
+        return new self(self::COMPLETED, ['fullText' => $fullText]);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(self::ERROR, ['message' => $message]);
+    }
+
+    /** @return array<string, mixed> */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return ['type' => $this->type, ...$this->data];
+    }
+}

--- a/src/Runtime/AgentFactory.php
+++ b/src/Runtime/AgentFactory.php
@@ -10,7 +10,6 @@ use BEAR\ToolUse\Llm\LlmClientInterface;
 use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
 use BEAR\ToolUse\Schema\Tool;
 use BEAR\ToolUse\Schema\ToolCollectorInterface;
-use RuntimeException;
 
 /**
  * Factory for creating Agent instances
@@ -68,7 +67,7 @@ final class AgentFactory
     public function createStreaming(string $systemPrompt, int $maxIterations = 10): StreamingAgentInterface
     {
         if ($this->streamingClient === null) {
-            throw new RuntimeException('StreamingLlmClientInterface is not configured');
+            throw new StreamingNotConfiguredException('StreamingLlmClientInterface is not configured');
         }
 
         return new StreamingAgent(

--- a/src/Runtime/AgentFactory.php
+++ b/src/Runtime/AgentFactory.php
@@ -7,8 +7,10 @@ namespace BEAR\ToolUse\Runtime;
 use BEAR\ToolUse\Dispatch\DispatcherInterface;
 use BEAR\ToolUse\Dispatch\ToolRegistryInterface;
 use BEAR\ToolUse\Llm\LlmClientInterface;
+use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
 use BEAR\ToolUse\Schema\Tool;
 use BEAR\ToolUse\Schema\ToolCollectorInterface;
+use RuntimeException;
 
 /**
  * Factory for creating Agent instances
@@ -24,6 +26,7 @@ final class AgentFactory
         private readonly ToolCollectorInterface $collector,
         private readonly ToolRegistryInterface $registry,
         private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
+        private readonly StreamingLlmClientInterface|null $streamingClient = null,
     ) {
     }
 
@@ -56,6 +59,24 @@ final class AgentFactory
             systemPrompt: $systemPrompt,
             maxIterations: $maxIterations,
             confirmationHandler: $this->confirmationHandler,
+        );
+    }
+
+    /**
+     * Create the streaming agent
+     */
+    public function createStreaming(string $systemPrompt, int $maxIterations = 10): StreamingAgentInterface
+    {
+        if ($this->streamingClient === null) {
+            throw new RuntimeException('StreamingLlmClientInterface is not configured');
+        }
+
+        return new StreamingAgent(
+            client: $this->streamingClient,
+            dispatcher: $this->dispatcher,
+            tools: $this->tools,
+            systemPrompt: $systemPrompt,
+            maxIterations: $maxIterations,
         );
     }
 

--- a/src/Runtime/StreamContentAccumulator.php
+++ b/src/Runtime/StreamContentAccumulator.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Llm\StreamEvent;
+
+use function is_string;
+use function json_decode;
+
+/**
+ * Accumulates stream events into content blocks and iteration state
+ *
+ * @psalm-import-type PendingToolCall from StreamIterationState
+ * @psalm-import-type ContentBlock from StreamIterationState
+ */
+final class StreamContentAccumulator
+{
+    private string $currentText = '';
+    private bool $needsSeparator;
+    private string $stopReason = 'end_turn';
+    private string $currentToolId = '';
+    private string $currentToolName = '';
+    private string $currentToolInputJson = '';
+
+    /** @var list<PendingToolCall> */
+    private array $pendingToolCalls = [];
+
+    /** @var list<ContentBlock> */
+    private array $contentBlocks = [];
+
+    public function __construct(bool $hadPreviousText, private string $fullText)
+    {
+        $this->needsSeparator = $hadPreviousText;
+    }
+
+    /** @return list<AgentEvent> */
+    public function handleEvent(StreamEvent $event): array
+    {
+        return match ($event->type) {
+            StreamEvent::TEXT_DELTA => $this->handleTextDelta($event),
+            StreamEvent::TOOL_USE_START => $this->handleToolUseStart($event),
+            StreamEvent::TOOL_USE_DELTA => $this->handleToolUseDelta($event),
+            StreamEvent::CONTENT_BLOCK_STOP => $this->handleContentBlockStop(),
+            StreamEvent::MESSAGE_STOP => $this->handleMessageStop($event),
+            default => [],
+        };
+    }
+
+    public function toState(): StreamIterationState
+    {
+        return new StreamIterationState(
+            stopReason: $this->stopReason,
+            currentText: $this->currentText,
+            pendingToolCalls: $this->pendingToolCalls,
+            contentBlocks: $this->contentBlocks,
+            fullText: $this->fullText,
+        );
+    }
+
+    /** @return list<AgentEvent> */
+    private function handleTextDelta(StreamEvent $event): array
+    {
+        $text = $this->eventString($event, 'text');
+        $events = [];
+
+        if ($this->needsSeparator) {
+            $this->fullText .= "\n";
+            $events[] = AgentEvent::textDelta("\n");
+            $this->needsSeparator = false;
+        }
+
+        $this->currentText .= $text;
+        $this->fullText .= $text;
+        $events[] = AgentEvent::textDelta($text);
+
+        return $events;
+    }
+
+    /** @return list<AgentEvent> */
+    private function handleToolUseStart(StreamEvent $event): array
+    {
+        $this->currentToolId = $this->eventString($event, 'id');
+        $this->currentToolName = $this->eventString($event, 'name');
+        $this->currentToolInputJson = '';
+
+        return [AgentEvent::toolStart($this->currentToolName)];
+    }
+
+    /** @return list<AgentEvent> */
+    private function handleToolUseDelta(StreamEvent $event): array
+    {
+        $this->currentToolInputJson .= $this->eventString($event, 'input');
+
+        return [];
+    }
+
+    /** @return list<AgentEvent> */
+    private function handleContentBlockStop(): array
+    {
+        $this->finalizeContentBlock();
+        $this->currentToolId = '';
+        $this->currentToolName = '';
+        $this->currentToolInputJson = '';
+
+        return [];
+    }
+
+    /** @return list<AgentEvent> */
+    private function handleMessageStop(StreamEvent $event): array
+    {
+        $this->stopReason = $this->eventString($event, 'stopReason', 'end_turn');
+
+        return [];
+    }
+
+    private function finalizeContentBlock(): void
+    {
+        if ($this->currentToolName !== '') {
+            $this->pendingToolCalls[] = [
+                'id' => $this->currentToolId,
+                'name' => $this->currentToolName,
+                'inputJson' => $this->currentToolInputJson,
+            ];
+            /** @var array<string, mixed> $input */
+            $input = (array) json_decode($this->currentToolInputJson, true);
+            $this->contentBlocks[] = [
+                'type' => 'tool_use',
+                'id' => $this->currentToolId,
+                'name' => $this->currentToolName,
+                'input' => $input,
+            ];
+
+            return;
+        }
+
+        if ($this->currentText === '') {
+            return;
+        }
+
+        $this->contentBlocks[] = ['type' => 'text', 'text' => $this->currentText];
+    }
+
+    private function eventString(StreamEvent $event, string $key, string $default = ''): string
+    {
+        $value = $event->data[$key] ?? $default;
+
+        return is_string($value) ? $value : $default;
+    }
+}

--- a/src/Runtime/StreamIterationState.php
+++ b/src/Runtime/StreamIterationState.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+/**
+ * State accumulated during a single streaming iteration
+ *
+ * @psalm-type PendingToolCall = array{id: string, name: string, inputJson: string}
+ * @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
+ */
+final readonly class StreamIterationState
+{
+    /**
+     * @param list<PendingToolCall> $pendingToolCalls
+     * @param list<ContentBlock>    $contentBlocks
+     */
+    public function __construct(
+        public string $stopReason,
+        public string $currentText,
+        public array $pendingToolCalls,
+        public array $contentBlocks,
+        public string $fullText,
+    ) {
+    }
+}

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
+use BEAR\ToolUse\Schema\Tool;
+use Generator;
+use Override;
+use Throwable;
+
+use function json_decode;
+
+/**
+ * Streaming agent runtime
+ *
+ * Yields AgentEvent instances as the LLM generates output.
+ * Text deltas are yielded immediately for real-time display.
+ * Tool calls are executed and results fed back to the LLM.
+ */
+final class StreamingAgent implements StreamingAgentInterface
+{
+    /** @var list<Message> */
+    public array $messages = [];
+
+    /** @param list<Tool> $tools */
+    public function __construct(
+        private readonly StreamingLlmClientInterface $client,
+        private readonly DispatcherInterface $dispatcher,
+        private readonly array $tools,
+        private readonly string $systemPrompt,
+        private readonly int $maxIterations = 10,
+    ) {
+    }
+
+    /** @return Generator<int, AgentEvent, void> */
+    #[Override]
+    public function runStream(string $userMessage): Generator
+    {
+        $this->messages[] = Message::user($userMessage);
+        $fullText = '';
+        $hadPreviousText = false;
+
+        for ($i = 0; $i < $this->maxIterations; $i++) {
+            $stream = $this->client->chatStream(
+                system: $this->systemPrompt,
+                messages: $this->messages,
+                tools: $this->tools,
+            );
+
+            $currentText = '';
+            $needsSeparator = $hadPreviousText;
+            $stopReason = 'end_turn';
+            /** @var list<array{id: string, name: string, inputJson: string}> $pendingToolCalls */
+            $pendingToolCalls = [];
+            $currentToolId = '';
+            $currentToolName = '';
+            $currentToolInputJson = '';
+            /** @var list<array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}> $contentBlocks */
+            $contentBlocks = [];
+
+            foreach ($stream as $event) {
+                switch ($event->type) {
+                    case StreamEvent::TEXT_DELTA:
+                        $text = (string) ($event->data['text'] ?? '');
+                        if ($needsSeparator) {
+                            $fullText .= "\n";
+
+                            yield AgentEvent::textDelta("\n");
+
+                            $needsSeparator = false;
+                        }
+
+                        $currentText .= $text;
+                        $fullText .= $text;
+
+                        yield AgentEvent::textDelta($text);
+
+                        break;
+
+                    case StreamEvent::TOOL_USE_START:
+                        $currentToolId = (string) ($event->data['id'] ?? '');
+                        $currentToolName = (string) ($event->data['name'] ?? '');
+                        $currentToolInputJson = '';
+
+                        yield AgentEvent::toolStart($currentToolName);
+
+                        break;
+
+                    case StreamEvent::TOOL_USE_DELTA:
+                        $currentToolInputJson .= (string) ($event->data['input'] ?? '');
+
+                        break;
+
+                    case StreamEvent::CONTENT_BLOCK_STOP:
+                        if ($currentToolName !== '') {
+                            $pendingToolCalls[] = [
+                                'id' => $currentToolId,
+                                'name' => $currentToolName,
+                                'inputJson' => $currentToolInputJson,
+                            ];
+                            /** @var array<string, mixed> $input */
+                            $input = json_decode($currentToolInputJson, true) ?: [];
+                            $contentBlocks[] = [
+                                'type' => 'tool_use',
+                                'id' => $currentToolId,
+                                'name' => $currentToolName,
+                                'input' => $input,
+                            ];
+                            $currentToolId = '';
+                            $currentToolName = '';
+                            $currentToolInputJson = '';
+                        } elseif ($currentText !== '') {
+                            $contentBlocks[] = ['type' => 'text', 'text' => $currentText];
+                        }
+
+                        break;
+
+                    case StreamEvent::MESSAGE_STOP:
+                        $stopReason = (string) ($event->data['stopReason'] ?? 'end_turn');
+
+                        break;
+                }
+            }
+
+            if ($stopReason === 'end_turn') {
+                if ($contentBlocks !== []) {
+                    $this->messages[] = Message::assistant($contentBlocks);
+                }
+
+                yield AgentEvent::completed($fullText);
+
+                return;
+            }
+
+            if ($stopReason === 'tool_use' && $pendingToolCalls !== []) {
+                $this->messages[] = Message::assistant($contentBlocks);
+
+                $toolResults = [];
+                foreach ($pendingToolCalls as $pending) {
+                    /** @var array<string, mixed> $input */
+                    $input = json_decode($pending['inputJson'], true) ?: [];
+                    $toolCall = new ToolCall(
+                        id: $pending['id'],
+                        name: $pending['name'],
+                        input: $input,
+                    );
+
+                    try {
+                        $result = $this->dispatcher->dispatch($toolCall);
+                    } catch (Throwable $e) {
+                        $result = ToolResult::error($toolCall->id, $e::class . ': ' . $e->getMessage());
+                    }
+
+                    $toolResults[] = $result;
+
+                    yield AgentEvent::toolResult($pending['name']);
+                }
+
+                $this->messages[] = Message::toolResults($toolResults);
+                if ($currentText !== '') {
+                    $hadPreviousText = true;
+                }
+
+                continue;
+            }
+
+            // Other stop reasons (max_tokens, stop_sequence) - complete
+            yield AgentEvent::completed($fullText);
+
+            return;
+        }
+
+        yield AgentEvent::error('Max iterations reached');
+    }
+
+    #[Override]
+    public function reset(): void
+    {
+        $this->messages = [];
+    }
+}

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -24,8 +24,8 @@ use function json_decode;
  * Text deltas are yielded immediately for real-time display.
  * Tool calls are executed and results fed back to the LLM.
  *
- * @psalm-type PendingToolCall = array{id: string, name: string, inputJson: string}
- * @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
+ * @psalm-import-type PendingToolCall from StreamIterationState
+ * @psalm-import-type ContentBlock from StreamIterationState
  */
 final class StreamingAgent implements StreamingAgentInterface
 {
@@ -62,13 +62,12 @@ final class StreamingAgent implements StreamingAgentInterface
                 yield $event;
             }
 
-            /** @var array{stopReason: string, currentText: string, pendingToolCalls: list<PendingToolCall>, contentBlocks: list<ContentBlock>, fullText: string} $state */
             $state = $consumeGen->getReturn();
-            $fullText = $state['fullText'];
+            $fullText = $state->fullText;
 
-            if ($state['stopReason'] === 'end_turn') {
-                if ($state['contentBlocks'] !== []) {
-                    $this->messages[] = Message::assistant($state['contentBlocks']);
+            if ($state->stopReason === 'end_turn') {
+                if ($state->contentBlocks !== []) {
+                    $this->messages[] = Message::assistant($state->contentBlocks);
                 }
 
                 yield AgentEvent::completed($fullText);
@@ -76,9 +75,9 @@ final class StreamingAgent implements StreamingAgentInterface
                 return;
             }
 
-            if ($state['stopReason'] === 'tool_use' && $state['pendingToolCalls'] !== []) {
-                $this->messages[] = Message::assistant($state['contentBlocks']);
-                $dispatchGen = $this->dispatchPendingToolCalls($state['pendingToolCalls']);
+            if ($state->stopReason === 'tool_use' && $state->pendingToolCalls !== []) {
+                $this->messages[] = Message::assistant($state->contentBlocks);
+                $dispatchGen = $this->dispatchPendingToolCalls($state->pendingToolCalls);
                 foreach ($dispatchGen as $event) {
                     yield $event;
                 }
@@ -86,7 +85,7 @@ final class StreamingAgent implements StreamingAgentInterface
                 /** @var list<ToolResult> $toolResults */
                 $toolResults = $dispatchGen->getReturn();
                 $this->messages[] = Message::toolResults($toolResults);
-                if ($state['currentText'] !== '') {
+                if ($state->currentText !== '') {
                     $hadPreviousText = true;
                 }
 
@@ -113,7 +112,7 @@ final class StreamingAgent implements StreamingAgentInterface
      *
      * @param Generator<int, StreamEvent, mixed, void> $stream
      *
-     * @return Generator<int, AgentEvent, mixed, array{stopReason: string, currentText: string, pendingToolCalls: list<PendingToolCall>, contentBlocks: list<ContentBlock>, fullText: string}>
+     * @return Generator<int, AgentEvent, mixed, StreamIterationState>
      */
     private function consumeStream(Generator $stream, bool $hadPreviousText, string $fullText): Generator
     {
@@ -162,14 +161,14 @@ final class StreamingAgent implements StreamingAgentInterface
                     break;
 
                 case StreamEvent::CONTENT_BLOCK_STOP:
-                    $this->finalizeContentBlock(
+                    $block = $this->buildContentBlock(
                         $currentToolName,
                         $currentToolId,
                         $currentToolInputJson,
                         $currentText,
-                        $pendingToolCalls,
-                        $contentBlocks,
                     );
+                    $pendingToolCalls = [...$pendingToolCalls, ...$block['pendingToolCalls']];
+                    $contentBlocks = [...$contentBlocks, ...$block['contentBlocks']];
                     $currentToolId = '';
                     $currentToolName = '';
                     $currentToolInputJson = '';
@@ -183,13 +182,13 @@ final class StreamingAgent implements StreamingAgentInterface
             }
         }
 
-        return [
-            'stopReason' => $stopReason,
-            'currentText' => $currentText,
-            'pendingToolCalls' => $pendingToolCalls,
-            'contentBlocks' => $contentBlocks,
-            'fullText' => $fullText,
-        ];
+        return new StreamIterationState(
+            stopReason: $stopReason,
+            currentText: $currentText,
+            pendingToolCalls: $pendingToolCalls,
+            contentBlocks: $contentBlocks,
+            fullText: $fullText,
+        );
     }
 
     /**
@@ -226,36 +225,34 @@ final class StreamingAgent implements StreamingAgentInterface
     }
 
     /**
-     * Finalize a content block when CONTENT_BLOCK_STOP is received
+     * Build content block data from accumulated stream state
      *
-     * @param list<PendingToolCall> $pendingToolCalls
-     * @param list<ContentBlock>    $contentBlocks
+     * @return array{pendingToolCalls: list<PendingToolCall>, contentBlocks: list<ContentBlock>}
      */
-    private function finalizeContentBlock(
+    private function buildContentBlock(
         string $toolName,
         string $toolId,
         string $toolInputJson,
         string $currentText,
-        array &$pendingToolCalls,
-        array &$contentBlocks,
-    ): void {
+    ): array {
         if ($toolName !== '') {
-            $pendingToolCalls[] = [
-                'id' => $toolId,
-                'name' => $toolName,
-                'inputJson' => $toolInputJson,
-            ];
             /** @var array<string, mixed> $input */
             $input = (array) json_decode($toolInputJson, true);
-            $contentBlocks[] = [
-                'type' => 'tool_use',
-                'id' => $toolId,
-                'name' => $toolName,
-                'input' => $input,
+
+            return [
+                'pendingToolCalls' => [['id' => $toolId, 'name' => $toolName, 'inputJson' => $toolInputJson]],
+                'contentBlocks' => [['type' => 'tool_use', 'id' => $toolId, 'name' => $toolName, 'input' => $input]],
             ];
-        } elseif ($currentText !== '') {
-            $contentBlocks[] = ['type' => 'text', 'text' => $currentText];
         }
+
+        if ($currentText !== '') {
+            return [
+                'pendingToolCalls' => [],
+                'contentBlocks' => [['type' => 'text', 'text' => $currentText]],
+            ];
+        }
+
+        return ['pendingToolCalls' => [], 'contentBlocks' => []];
     }
 
     /** Extract a string value from stream event data */

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -14,6 +14,7 @@ use Generator;
 use Override;
 use Throwable;
 
+use function is_string;
 use function json_decode;
 
 /**
@@ -22,6 +23,9 @@ use function json_decode;
  * Yields AgentEvent instances as the LLM generates output.
  * Text deltas are yielded immediately for real-time display.
  * Tool calls are executed and results fed back to the LLM.
+ *
+ * @psalm-type PendingToolCall = array{id: string, name: string, inputJson: string}
+ * @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
  */
 final class StreamingAgent implements StreamingAgentInterface
 {
@@ -38,7 +42,7 @@ final class StreamingAgent implements StreamingAgentInterface
     ) {
     }
 
-    /** @return Generator<int, AgentEvent, void> */
+    /** @return Generator<int, AgentEvent, mixed, void> */
     #[Override]
     public function runStream(string $userMessage): Generator
     {
@@ -53,84 +57,18 @@ final class StreamingAgent implements StreamingAgentInterface
                 tools: $this->tools,
             );
 
-            $currentText = '';
-            $needsSeparator = $hadPreviousText;
-            $stopReason = 'end_turn';
-            /** @var list<array{id: string, name: string, inputJson: string}> $pendingToolCalls */
-            $pendingToolCalls = [];
-            $currentToolId = '';
-            $currentToolName = '';
-            $currentToolInputJson = '';
-            /** @var list<array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}> $contentBlocks */
-            $contentBlocks = [];
-
-            foreach ($stream as $event) {
-                switch ($event->type) {
-                    case StreamEvent::TEXT_DELTA:
-                        $text = (string) ($event->data['text'] ?? '');
-                        if ($needsSeparator) {
-                            $fullText .= "\n";
-
-                            yield AgentEvent::textDelta("\n");
-
-                            $needsSeparator = false;
-                        }
-
-                        $currentText .= $text;
-                        $fullText .= $text;
-
-                        yield AgentEvent::textDelta($text);
-
-                        break;
-
-                    case StreamEvent::TOOL_USE_START:
-                        $currentToolId = (string) ($event->data['id'] ?? '');
-                        $currentToolName = (string) ($event->data['name'] ?? '');
-                        $currentToolInputJson = '';
-
-                        yield AgentEvent::toolStart($currentToolName);
-
-                        break;
-
-                    case StreamEvent::TOOL_USE_DELTA:
-                        $currentToolInputJson .= (string) ($event->data['input'] ?? '');
-
-                        break;
-
-                    case StreamEvent::CONTENT_BLOCK_STOP:
-                        if ($currentToolName !== '') {
-                            $pendingToolCalls[] = [
-                                'id' => $currentToolId,
-                                'name' => $currentToolName,
-                                'inputJson' => $currentToolInputJson,
-                            ];
-                            /** @var array<string, mixed> $input */
-                            $input = json_decode($currentToolInputJson, true) ?: [];
-                            $contentBlocks[] = [
-                                'type' => 'tool_use',
-                                'id' => $currentToolId,
-                                'name' => $currentToolName,
-                                'input' => $input,
-                            ];
-                            $currentToolId = '';
-                            $currentToolName = '';
-                            $currentToolInputJson = '';
-                        } elseif ($currentText !== '') {
-                            $contentBlocks[] = ['type' => 'text', 'text' => $currentText];
-                        }
-
-                        break;
-
-                    case StreamEvent::MESSAGE_STOP:
-                        $stopReason = (string) ($event->data['stopReason'] ?? 'end_turn');
-
-                        break;
-                }
+            $consumeGen = $this->consumeStream($stream, $hadPreviousText, $fullText);
+            foreach ($consumeGen as $event) {
+                yield $event;
             }
 
-            if ($stopReason === 'end_turn') {
-                if ($contentBlocks !== []) {
-                    $this->messages[] = Message::assistant($contentBlocks);
+            /** @var array{stopReason: string, currentText: string, pendingToolCalls: list<PendingToolCall>, contentBlocks: list<ContentBlock>, fullText: string} $state */
+            $state = $consumeGen->getReturn();
+            $fullText = $state['fullText'];
+
+            if ($state['stopReason'] === 'end_turn') {
+                if ($state['contentBlocks'] !== []) {
+                    $this->messages[] = Message::assistant($state['contentBlocks']);
                 }
 
                 yield AgentEvent::completed($fullText);
@@ -138,32 +76,17 @@ final class StreamingAgent implements StreamingAgentInterface
                 return;
             }
 
-            if ($stopReason === 'tool_use' && $pendingToolCalls !== []) {
-                $this->messages[] = Message::assistant($contentBlocks);
-
-                $toolResults = [];
-                foreach ($pendingToolCalls as $pending) {
-                    /** @var array<string, mixed> $input */
-                    $input = json_decode($pending['inputJson'], true) ?: [];
-                    $toolCall = new ToolCall(
-                        id: $pending['id'],
-                        name: $pending['name'],
-                        input: $input,
-                    );
-
-                    try {
-                        $result = $this->dispatcher->dispatch($toolCall);
-                    } catch (Throwable $e) {
-                        $result = ToolResult::error($toolCall->id, $e::class . ': ' . $e->getMessage());
-                    }
-
-                    $toolResults[] = $result;
-
-                    yield AgentEvent::toolResult($pending['name']);
+            if ($state['stopReason'] === 'tool_use' && $state['pendingToolCalls'] !== []) {
+                $this->messages[] = Message::assistant($state['contentBlocks']);
+                $dispatchGen = $this->dispatchPendingToolCalls($state['pendingToolCalls']);
+                foreach ($dispatchGen as $event) {
+                    yield $event;
                 }
 
+                /** @var list<ToolResult> $toolResults */
+                $toolResults = $dispatchGen->getReturn();
                 $this->messages[] = Message::toolResults($toolResults);
-                if ($currentText !== '') {
+                if ($state['currentText'] !== '') {
                     $hadPreviousText = true;
                 }
 
@@ -183,5 +106,163 @@ final class StreamingAgent implements StreamingAgentInterface
     public function reset(): void
     {
         $this->messages = [];
+    }
+
+    /**
+     * Consume stream events and yield AgentEvents
+     *
+     * @param Generator<int, StreamEvent, mixed, void> $stream
+     *
+     * @return Generator<int, AgentEvent, mixed, array{stopReason: string, currentText: string, pendingToolCalls: list<PendingToolCall>, contentBlocks: list<ContentBlock>, fullText: string}>
+     */
+    private function consumeStream(Generator $stream, bool $hadPreviousText, string $fullText): Generator
+    {
+        $currentText = '';
+        $needsSeparator = $hadPreviousText;
+        $stopReason = 'end_turn';
+        /** @var list<PendingToolCall> $pendingToolCalls */
+        $pendingToolCalls = [];
+        $currentToolId = '';
+        $currentToolName = '';
+        $currentToolInputJson = '';
+        /** @var list<ContentBlock> $contentBlocks */
+        $contentBlocks = [];
+
+        foreach ($stream as $event) {
+            switch ($event->type) {
+                case StreamEvent::TEXT_DELTA:
+                    $text = $this->eventString($event, 'text');
+                    if ($needsSeparator) {
+                        $fullText .= "\n";
+
+                        yield AgentEvent::textDelta("\n");
+
+                        $needsSeparator = false;
+                    }
+
+                    $currentText .= $text;
+                    $fullText .= $text;
+
+                    yield AgentEvent::textDelta($text);
+
+                    break;
+
+                case StreamEvent::TOOL_USE_START:
+                    $currentToolId = $this->eventString($event, 'id');
+                    $currentToolName = $this->eventString($event, 'name');
+                    $currentToolInputJson = '';
+
+                    yield AgentEvent::toolStart($currentToolName);
+
+                    break;
+
+                case StreamEvent::TOOL_USE_DELTA:
+                    $currentToolInputJson .= $this->eventString($event, 'input');
+
+                    break;
+
+                case StreamEvent::CONTENT_BLOCK_STOP:
+                    $this->finalizeContentBlock(
+                        $currentToolName,
+                        $currentToolId,
+                        $currentToolInputJson,
+                        $currentText,
+                        $pendingToolCalls,
+                        $contentBlocks,
+                    );
+                    $currentToolId = '';
+                    $currentToolName = '';
+                    $currentToolInputJson = '';
+
+                    break;
+
+                case StreamEvent::MESSAGE_STOP:
+                    $stopReason = $this->eventString($event, 'stopReason', 'end_turn');
+
+                    break;
+            }
+        }
+
+        return [
+            'stopReason' => $stopReason,
+            'currentText' => $currentText,
+            'pendingToolCalls' => $pendingToolCalls,
+            'contentBlocks' => $contentBlocks,
+            'fullText' => $fullText,
+        ];
+    }
+
+    /**
+     * Dispatch pending tool calls and yield result events
+     *
+     * @param list<PendingToolCall> $pendingToolCalls
+     *
+     * @return Generator<int, AgentEvent, mixed, list<ToolResult>>
+     */
+    private function dispatchPendingToolCalls(array $pendingToolCalls): Generator
+    {
+        $toolResults = [];
+        foreach ($pendingToolCalls as $pending) {
+            /** @var array<string, mixed> $input */
+            $input = (array) json_decode($pending['inputJson'], true);
+            $toolCall = new ToolCall(
+                id: $pending['id'],
+                name: $pending['name'],
+                input: $input,
+            );
+
+            try {
+                $result = $this->dispatcher->dispatch($toolCall);
+            } catch (Throwable $e) {
+                $result = ToolResult::error($toolCall->id, $e::class . ': ' . $e->getMessage());
+            }
+
+            $toolResults[] = $result;
+
+            yield AgentEvent::toolResult($pending['name']);
+        }
+
+        return $toolResults;
+    }
+
+    /**
+     * Finalize a content block when CONTENT_BLOCK_STOP is received
+     *
+     * @param list<PendingToolCall> $pendingToolCalls
+     * @param list<ContentBlock>    $contentBlocks
+     */
+    private function finalizeContentBlock(
+        string $toolName,
+        string $toolId,
+        string $toolInputJson,
+        string $currentText,
+        array &$pendingToolCalls,
+        array &$contentBlocks,
+    ): void {
+        if ($toolName !== '') {
+            $pendingToolCalls[] = [
+                'id' => $toolId,
+                'name' => $toolName,
+                'inputJson' => $toolInputJson,
+            ];
+            /** @var array<string, mixed> $input */
+            $input = (array) json_decode($toolInputJson, true);
+            $contentBlocks[] = [
+                'type' => 'tool_use',
+                'id' => $toolId,
+                'name' => $toolName,
+                'input' => $input,
+            ];
+        } elseif ($currentText !== '') {
+            $contentBlocks[] = ['type' => 'text', 'text' => $currentText];
+        }
+    }
+
+    /** Extract a string value from stream event data */
+    private function eventString(StreamEvent $event, string $key, string $default = ''): string
+    {
+        $value = $event->data[$key] ?? $default;
+
+        return is_string($value) ? $value : $default;
     }
 }

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -14,7 +14,6 @@ use Generator;
 use Override;
 use Throwable;
 
-use function is_string;
 use function json_decode;
 
 /**
@@ -25,7 +24,6 @@ use function json_decode;
  * Tool calls are executed and results fed back to the LLM.
  *
  * @psalm-import-type PendingToolCall from StreamIterationState
- * @psalm-import-type ContentBlock from StreamIterationState
  */
 final class StreamingAgent implements StreamingAgentInterface
 {
@@ -66,9 +64,7 @@ final class StreamingAgent implements StreamingAgentInterface
             $fullText = $state->fullText;
 
             if ($state->stopReason === 'end_turn') {
-                if ($state->contentBlocks !== []) {
-                    $this->messages[] = Message::assistant($state->contentBlocks);
-                }
+                $this->recordContentBlocks($state);
 
                 yield AgentEvent::completed($fullText);
 
@@ -107,6 +103,15 @@ final class StreamingAgent implements StreamingAgentInterface
         $this->messages = [];
     }
 
+    private function recordContentBlocks(StreamIterationState $state): void
+    {
+        if ($state->contentBlocks === []) {
+            return;
+        }
+
+        $this->messages[] = Message::assistant($state->contentBlocks);
+    }
+
     /**
      * Consume stream events and yield AgentEvents
      *
@@ -116,79 +121,15 @@ final class StreamingAgent implements StreamingAgentInterface
      */
     private function consumeStream(Generator $stream, bool $hadPreviousText, string $fullText): Generator
     {
-        $currentText = '';
-        $needsSeparator = $hadPreviousText;
-        $stopReason = 'end_turn';
-        /** @var list<PendingToolCall> $pendingToolCalls */
-        $pendingToolCalls = [];
-        $currentToolId = '';
-        $currentToolName = '';
-        $currentToolInputJson = '';
-        /** @var list<ContentBlock> $contentBlocks */
-        $contentBlocks = [];
+        $accumulator = new StreamContentAccumulator($hadPreviousText, $fullText);
 
         foreach ($stream as $event) {
-            switch ($event->type) {
-                case StreamEvent::TEXT_DELTA:
-                    $text = $this->eventString($event, 'text');
-                    if ($needsSeparator) {
-                        $fullText .= "\n";
-
-                        yield AgentEvent::textDelta("\n");
-
-                        $needsSeparator = false;
-                    }
-
-                    $currentText .= $text;
-                    $fullText .= $text;
-
-                    yield AgentEvent::textDelta($text);
-
-                    break;
-
-                case StreamEvent::TOOL_USE_START:
-                    $currentToolId = $this->eventString($event, 'id');
-                    $currentToolName = $this->eventString($event, 'name');
-                    $currentToolInputJson = '';
-
-                    yield AgentEvent::toolStart($currentToolName);
-
-                    break;
-
-                case StreamEvent::TOOL_USE_DELTA:
-                    $currentToolInputJson .= $this->eventString($event, 'input');
-
-                    break;
-
-                case StreamEvent::CONTENT_BLOCK_STOP:
-                    $block = $this->buildContentBlock(
-                        $currentToolName,
-                        $currentToolId,
-                        $currentToolInputJson,
-                        $currentText,
-                    );
-                    $pendingToolCalls = [...$pendingToolCalls, ...$block['pendingToolCalls']];
-                    $contentBlocks = [...$contentBlocks, ...$block['contentBlocks']];
-                    $currentToolId = '';
-                    $currentToolName = '';
-                    $currentToolInputJson = '';
-
-                    break;
-
-                case StreamEvent::MESSAGE_STOP:
-                    $stopReason = $this->eventString($event, 'stopReason', 'end_turn');
-
-                    break;
+            foreach ($accumulator->handleEvent($event) as $agentEvent) {
+                yield $agentEvent;
             }
         }
 
-        return new StreamIterationState(
-            stopReason: $stopReason,
-            currentText: $currentText,
-            pendingToolCalls: $pendingToolCalls,
-            contentBlocks: $contentBlocks,
-            fullText: $fullText,
-        );
+        return $accumulator->toState();
     }
 
     /**
@@ -222,44 +163,5 @@ final class StreamingAgent implements StreamingAgentInterface
         }
 
         return $toolResults;
-    }
-
-    /**
-     * Build content block data from accumulated stream state
-     *
-     * @return array{pendingToolCalls: list<PendingToolCall>, contentBlocks: list<ContentBlock>}
-     */
-    private function buildContentBlock(
-        string $toolName,
-        string $toolId,
-        string $toolInputJson,
-        string $currentText,
-    ): array {
-        if ($toolName !== '') {
-            /** @var array<string, mixed> $input */
-            $input = (array) json_decode($toolInputJson, true);
-
-            return [
-                'pendingToolCalls' => [['id' => $toolId, 'name' => $toolName, 'inputJson' => $toolInputJson]],
-                'contentBlocks' => [['type' => 'tool_use', 'id' => $toolId, 'name' => $toolName, 'input' => $input]],
-            ];
-        }
-
-        if ($currentText !== '') {
-            return [
-                'pendingToolCalls' => [],
-                'contentBlocks' => [['type' => 'text', 'text' => $currentText]],
-            ];
-        }
-
-        return ['pendingToolCalls' => [], 'contentBlocks' => []];
-    }
-
-    /** Extract a string value from stream event data */
-    private function eventString(StreamEvent $event, string $key, string $default = ''): string
-    {
-        $value = $event->data[$key] ?? $default;
-
-        return is_string($value) ? $value : $default;
     }
 }

--- a/src/Runtime/StreamingAgentInterface.php
+++ b/src/Runtime/StreamingAgentInterface.php
@@ -14,7 +14,7 @@ interface StreamingAgentInterface
     /**
      * Run the agent with streaming output
      *
-     * @return Generator<int, AgentEvent, void>
+     * @return Generator<int, AgentEvent, mixed, void>
      */
     public function runStream(string $userMessage): Generator;
 

--- a/src/Runtime/StreamingAgentInterface.php
+++ b/src/Runtime/StreamingAgentInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use Generator;
+
+/**
+ * Streaming agent runtime
+ */
+interface StreamingAgentInterface
+{
+    /**
+     * Run the agent with streaming output
+     *
+     * @return Generator<int, AgentEvent, void>
+     */
+    public function runStream(string $userMessage): Generator;
+
+    /**
+     * Clear conversation history
+     */
+    public function reset(): void;
+}

--- a/src/Runtime/StreamingNotConfiguredException.php
+++ b/src/Runtime/StreamingNotConfiguredException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use LogicException;
+
+final class StreamingNotConfiguredException extends LogicException
+{
+}

--- a/tests/Fake/FakeStreamingLlmClient.php
+++ b/tests/Fake/FakeStreamingLlmClient.php
@@ -35,7 +35,7 @@ class FakeStreamingLlmClient implements StreamingLlmClientInterface
      * @param list<Message> $messages
      * @param list<Tool>    $tools
      *
-     * @return Generator<int, StreamEvent, void>
+     * @return Generator<int, StreamEvent, mixed, void>
      */
     #[Override]
     public function chatStream(string $system, array $messages, array $tools): Generator

--- a/tests/Fake/FakeStreamingLlmClient.php
+++ b/tests/Fake/FakeStreamingLlmClient.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
+use BEAR\ToolUse\Runtime\Message;
+use BEAR\ToolUse\Schema\Tool;
+use Generator;
+use Override;
+
+/**
+ * Fake streaming LLM client that yields preset stream events
+ */
+class FakeStreamingLlmClient implements StreamingLlmClientInterface
+{
+    /** @var list<list<StreamEvent>> */
+    private array $eventSequences = [];
+    private int $callCount = 0;
+
+    /** @var list<array{system: string, messages: list<Message>, tools: list<Tool>}> */
+    public array $calls = [];
+
+    /** @param list<list<StreamEvent>> $sequences */
+    public function setEventSequences(array $sequences): void
+    {
+        $this->eventSequences = $sequences;
+        $this->callCount = 0;
+        $this->calls = [];
+    }
+
+    /**
+     * @param list<Message> $messages
+     * @param list<Tool>    $tools
+     *
+     * @return Generator<int, StreamEvent, void>
+     */
+    #[Override]
+    public function chatStream(string $system, array $messages, array $tools): Generator
+    {
+        $this->calls[] = ['system' => $system, 'messages' => $messages, 'tools' => $tools];
+
+        $events = $this->eventSequences[$this->callCount] ?? [
+            new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'No more events configured']),
+            new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+            new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+        ];
+        $this->callCount++;
+
+        foreach ($events as $event) {
+            yield $event;
+        }
+    }
+}

--- a/tests/Fake/FakeThrowingDispatcher.php
+++ b/tests/Fake/FakeThrowingDispatcher.php
@@ -7,10 +7,12 @@ namespace BEAR\ToolUse\Fake;
 use BEAR\ToolUse\Dispatch\DispatcherInterface;
 use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Dispatch\ToolResult;
+use Override;
 use RuntimeException;
 
 class FakeThrowingDispatcher implements DispatcherInterface
 {
+    #[Override]
     public function dispatch(ToolCall $toolCall): ToolResult
     {
         throw new RuntimeException('Dispatch failed');

--- a/tests/Fake/FakeThrowingDispatcher.php
+++ b/tests/Fake/FakeThrowingDispatcher.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use RuntimeException;
+
+class FakeThrowingDispatcher implements DispatcherInterface
+{
+    public function dispatch(ToolCall $toolCall): ToolResult
+    {
+        throw new RuntimeException('Dispatch failed');
+    }
+}

--- a/tests/Runtime/AgentFactoryTest.php
+++ b/tests/Runtime/AgentFactoryTest.php
@@ -18,7 +18,6 @@ use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
-use RuntimeException;
 
 #[CoversClass(AgentFactory::class)]
 final class AgentFactoryTest extends TestCase
@@ -121,7 +120,7 @@ final class AgentFactoryTest extends TestCase
 
     public function testCreateStreamingAgentThrowsWhenNotConfigured(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(StreamingNotConfiguredException::class);
         $this->expectExceptionMessage('StreamingLlmClientInterface is not configured');
 
         $this->factory->createStreaming('You are a helpful assistant.');

--- a/tests/Runtime/AgentFactoryTest.php
+++ b/tests/Runtime/AgentFactoryTest.php
@@ -11,12 +11,14 @@ use BEAR\ToolUse\Dispatch\Dispatcher;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeConfirmationHandler;
 use BEAR\ToolUse\Fake\FakeLlmClient;
+use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Schema\SchemaConverter;
 use BEAR\ToolUse\Schema\ToolCollector;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
+use RuntimeException;
 
 #[CoversClass(AgentFactory::class)]
 final class AgentFactoryTest extends TestCase
@@ -95,6 +97,34 @@ final class AgentFactoryTest extends TestCase
 
         $tools = $this->factory->getTools();
         $this->assertCount(2, $tools);
+    }
+
+    public function testCreateStreamingAgent(): void
+    {
+        $streamingClient = new FakeStreamingLlmClient();
+        $injector        = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource        = $injector->getInstance(ResourceInterface::class);
+        $resourceFactory = $injector->getInstance(FactoryInterface::class);
+
+        $registry   = new ToolRegistry();
+        $converter  = new SchemaConverter(DocBlockFactory::createInstance());
+        $collector  = new ToolCollector($converter, $registry, $resourceFactory);
+        $dispatcher = new Dispatcher($resource, $registry);
+
+        $factory = new AgentFactory($this->llmClient, $dispatcher, $collector, $registry, null, $streamingClient);
+        $factory->addResources(['app://self/article']);
+
+        $agent = $factory->createStreaming('You are a helpful assistant.', 5);
+
+        $this->assertInstanceOf(StreamingAgent::class, $agent);
+    }
+
+    public function testCreateStreamingAgentThrowsWhenNotConfigured(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('StreamingLlmClientInterface is not configured');
+
+        $this->factory->createStreaming('You are a helpful assistant.');
     }
 
     public function testCreateAgentWithConfirmationHandler(): void

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -22,6 +22,7 @@ use function iterator_to_array;
 use function json_encode;
 
 #[CoversClass(StreamingAgent::class)]
+#[CoversClass(StreamIterationState::class)]
 #[CoversClass(AgentEvent::class)]
 #[CoversClass(StreamEvent::class)]
 final class StreamingAgentTest extends TestCase

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -9,6 +9,7 @@ use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
+use BEAR\ToolUse\Fake\FakeThrowingDispatcher;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Schema\Tool;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -204,11 +205,26 @@ final class StreamingAgentTest extends TestCase
 
     public function testToolDispatchException(): void
     {
-        $toolInput = json_encode(['id' => 999]);
+        $llmClient = new FakeStreamingLlmClient();
+        $tools = [
+            new Tool('article_get', 'Get an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ]),
+        ];
+        $agent = new StreamingAgent(
+            client: $llmClient,
+            dispatcher: new FakeThrowingDispatcher(),
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
 
-        $this->llmClient->setEventSequences([
+        $toolInput = json_encode(['id' => 1]);
+        $llmClient->setEventSequences([
             [
-                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'unknown_tool']),
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'article_get']),
                 new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
                 new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
                 new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
@@ -221,7 +237,7 @@ final class StreamingAgentTest extends TestCase
         ]);
 
         /** @var list<AgentEvent> $events */
-        $events = iterator_to_array($this->agent->runStream('Call unknown tool'));
+        $events = iterator_to_array($agent->runStream('Call tool'));
 
         $types = array_map(static fn (AgentEvent $e): string => $e->type, $events);
         self::assertContains(AgentEvent::TOOL_RESULT, $types);
@@ -260,6 +276,23 @@ final class StreamingAgentTest extends TestCase
 
         self::assertCount(1, $events);
         self::assertSame(AgentEvent::COMPLETED, $events[0]->type);
+    }
+
+    public function testToolUseWithEmptyPendingToolCalls(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Done']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Hi'));
+
+        $lastEvent = end($events);
+        self::assertSame(AgentEvent::COMPLETED, $lastEvent->type);
     }
 
     public function testConversationHistoryPreserved(): void

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+use function iterator_to_array;
+use function json_encode;
+
+#[CoversClass(StreamingAgent::class)]
+#[CoversClass(AgentEvent::class)]
+#[CoversClass(StreamEvent::class)]
+final class StreamingAgentTest extends TestCase
+{
+    private StreamingAgent $agent;
+    private FakeStreamingLlmClient $llmClient;
+
+    protected function setUp(): void
+    {
+        $this->llmClient = new FakeStreamingLlmClient();
+
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('article_get', 'article', 'get');
+        $dispatcher = new Dispatcher($resource, $registry);
+
+        $tools = [
+            new Tool('article_get', 'Get an article', [
+                'type' => 'object',
+                'properties' => ['id' => ['type' => 'integer']],
+                'required' => ['id'],
+            ]),
+        ];
+
+        $this->agent = new StreamingAgent(
+            client: $this->llmClient,
+            dispatcher: $dispatcher,
+            tools: $tools,
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    public function testSimpleTextStreaming(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Hello']),
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => ' world']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Hi'));
+
+        self::assertCount(3, $events);
+        self::assertSame(AgentEvent::TEXT_DELTA, $events[0]->type);
+        self::assertSame('Hello', $events[0]->data['text']);
+        self::assertSame(AgentEvent::TEXT_DELTA, $events[1]->type);
+        self::assertSame(' world', $events[1]->data['text']);
+        self::assertSame(AgentEvent::COMPLETED, $events[2]->type);
+        self::assertSame('Hello world', $events[2]->data['fullText']);
+    }
+
+    public function testToolUseStreaming(): void
+    {
+        $toolInput = json_encode(['id' => 123]);
+
+        $this->llmClient->setEventSequences([
+            // First call: LLM requests tool use
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Looking up...']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'article_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            // Second call: LLM responds after tool result
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Found it!']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Get article 123'));
+
+        // Expect: text_delta("Looking up..."), tool_start, tool_result, text_delta("\n"), text_delta("Found it!"), completed
+        $types = array_map(static fn (AgentEvent $e): string => $e->type, $events);
+        self::assertSame([
+            AgentEvent::TEXT_DELTA,
+            AgentEvent::TOOL_START,
+            AgentEvent::TOOL_RESULT,
+            AgentEvent::TEXT_DELTA,  // newline separator
+            AgentEvent::TEXT_DELTA,
+            AgentEvent::COMPLETED,
+        ], $types);
+
+        self::assertSame("\n", $events[3]->data['text']);
+        self::assertSame('article_get', $events[1]->data['toolName']);
+        self::assertSame('article_get', $events[2]->data['toolName']);
+        self::assertSame("Looking up...\nFound it!", $events[5]->data['fullText']);
+    }
+
+    public function testMaxIterationsReached(): void
+    {
+        $toolInput = json_encode(['id' => 1]);
+
+        $sequences = [];
+        for ($i = 0; $i < 6; $i++) {
+            $sequences[] = [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_' . $i, 'name' => 'article_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ];
+        }
+
+        $this->llmClient->setEventSequences($sequences);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Keep calling tools'));
+
+        $lastEvent = end($events);
+        self::assertSame(AgentEvent::ERROR, $lastEvent->type);
+        self::assertSame('Max iterations reached', $lastEvent->data['message']);
+    }
+
+    public function testReset(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Hello']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($this->agent->runStream('Hi'));
+        self::assertNotEmpty($this->agent->messages);
+
+        $this->agent->reset();
+        self::assertEmpty($this->agent->messages);
+    }
+
+    public function testAgentEventJsonSerialize(): void
+    {
+        $event = AgentEvent::textDelta('hello');
+        $json = json_encode($event);
+
+        self::assertSame('{"type":"text_delta","text":"hello"}', $json);
+    }
+
+    public function testAgentEventCompleted(): void
+    {
+        $event = AgentEvent::completed('full text');
+        $json = json_encode($event);
+
+        self::assertSame('{"type":"completed","fullText":"full text"}', $json);
+    }
+
+    public function testAgentEventError(): void
+    {
+        $event = AgentEvent::error('something failed');
+        self::assertSame(AgentEvent::ERROR, $event->type);
+        self::assertSame('something failed', $event->data['message']);
+    }
+
+    public function testConversationHistoryPreserved(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'First response']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($this->agent->runStream('First message'));
+
+        // 1 user message + 1 assistant message from content_block_stop
+        self::assertCount(2, $this->agent->messages);
+        self::assertSame('user', $this->agent->messages[0]->role);
+        self::assertSame('assistant', $this->agent->messages[1]->role);
+    }
+}

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
+use function array_map;
+use function end;
 use function iterator_to_array;
 use function json_encode;
 

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -22,6 +22,7 @@ use function iterator_to_array;
 use function json_encode;
 
 #[CoversClass(StreamingAgent::class)]
+#[CoversClass(StreamContentAccumulator::class)]
 #[CoversClass(StreamIterationState::class)]
 #[CoversClass(AgentEvent::class)]
 #[CoversClass(StreamEvent::class)]

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -184,6 +184,84 @@ final class StreamingAgentTest extends TestCase
         self::assertSame('something failed', $event->data['message']);
     }
 
+    public function testOtherStopReason(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Partial']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'max_tokens']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Hi'));
+
+        $lastEvent = end($events);
+        self::assertSame(AgentEvent::COMPLETED, $lastEvent->type);
+        self::assertSame('Partial', $lastEvent->data['fullText']);
+    }
+
+    public function testToolDispatchException(): void
+    {
+        $toolInput = json_encode(['id' => 999]);
+
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'unknown_tool']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Error handled']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Call unknown tool'));
+
+        $types = array_map(static fn (AgentEvent $e): string => $e->type, $events);
+        self::assertContains(AgentEvent::TOOL_RESULT, $types);
+        $lastEvent = end($events);
+        self::assertSame(AgentEvent::COMPLETED, $lastEvent->type);
+    }
+
+    public function testNonStringEventData(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 42]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Hi'));
+
+        self::assertSame(AgentEvent::TEXT_DELTA, $events[0]->type);
+        self::assertSame('', $events[0]->data['text']);
+    }
+
+    public function testEmptyContentBlockStop(): void
+    {
+        $this->llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($this->agent->runStream('Hi'));
+
+        self::assertCount(1, $events);
+        self::assertSame(AgentEvent::COMPLETED, $events[0]->type);
+    }
+
     public function testConversationHistoryPreserved(): void
     {
         $this->llmClient->setEventSequences([


### PR DESCRIPTION
## Summary

- Add `StreamingLlmClientInterface` — sibling to `LlmClientInterface` that returns `Generator<StreamEvent>` for streaming chat
- Add `StreamEvent` — low-level LLM stream events (text_delta, tool_use_start, tool_use_delta, content_block_stop, message_stop)
- Add `StreamingAgentInterface` / `StreamingAgent` — streaming agent loop that yields `AgentEvent` for real-time UI updates
- Add `AgentEvent` — high-level application events (text_delta, tool_start, tool_result, completed, error) with `JsonSerializable` for SSE
- Add `AgentFactory::createStreaming()` — creates a `StreamingAgent` when `StreamingLlmClientInterface` is provided
- Newline separator between iteration texts for readable multi-step output

### Design decisions

- `StreamingLlmClientInterface` is a sibling of `LlmClientInterface`, not a subtype — implementations can choose to implement one or both
- `StreamEvent` uses a single class with type constants (no class hierarchy)
- `AgentEvent` is the app-facing abstraction — maps low-level stream events to meaningful UI events
- `StreamingAgent` accumulates `fullText` across all iterations and includes it in the `completed` event
- Backward compatible: no changes to existing `Agent`, `LlmClientInterface`, or `AgentFactory::create()`

### Known limitations

- `StreamingAgent` does not support Human-in-the-Loop confirmation (`ConfirmationHandlerInterface` / `#[Tool(confirm: true)]`). Tracked in #9.

## Test plan

- [x] `StreamingAgentTest` — simple text streaming, tool use loop, max iterations, conversation history, reset
- [x] `AgentEvent` serialization tests
- [x] All existing tests pass (163 tests, 352 assertions)
- [x] PHPCS clean
- [x] PHPStan clean
- [x] Psalm clean
- [x] PHPMD clean
- [x] 100% code coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)