### PR TITLE
refactor: Replace koriym/app-state-diagram with inline ALPS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `#[Tool(confirm: true)]` for human-in-the-loop confirmation on destructive operations
 - `#[Tool(filter: FilterClass::class)]` for response body filtering before sending to LLM
 - JSON Schema integration for parameter validation (`#[JsonSchema]`)
-- ALPS semantic dictionary for parameter descriptions
+- ALPS semantic dictionary for parameter descriptions (JSON and XML profiles)
 - Parameter description resolution (JSON Schema > PHPDoc > ALPS)
 - Synchronous `Agent` with `ConfirmationHandlerInterface`
 - `StreamingAgent` for SSE real-time output with yield-based confirmation
@@ -20,3 +20,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ToolResult::cancelled()` for encapsulating cancellation results
 - Error feedback loop: exceptions and 4xx/5xx status codes fed back to LLM
 - `ToolUseModule` for Ray.Di binding configuration
+
+### Changed
+- **BREAKING**: `AlpsSemanticDictionary` now takes a profile file path (`string`) instead of a `Koriym\AppStateDiagram\Profile` instance.
+
+  ```php
+  // Before
+  $profile    = new Profile($path, new LabelNameTitle());
+  $dictionary = new AlpsSemanticDictionary($profile);
+
+  // After
+  $dictionary = new AlpsSemanticDictionary($path);
+  ```
+- ALPS parsing is now self-contained: JSON/XML format auto-detection, `type === 'semantic'` filter, and same-profile `href="#id"` resolution (including multi-hop chains) are handled internally.
+
+### Removed
+- Dependency on `koriym/app-state-diagram` (and its transitive deps `koriym/data-file`, `michelf/php-markdown`, `seld/jsonlint`, `symfony/polyfill-php81`). Approx 12 MB of vendor code eliminated.

--- a/README.ja.md
+++ b/README.ja.md
@@ -450,7 +450,7 @@ $dictionary = new AlpsSemanticDictionary('/path/to/profile.json');
 $converter = new SchemaConverter($dictionary);
 ```
 
-ALPSプロファイルの`semantic`記述子から`title`または`doc.value`がパラメータの説明として使用されます。
+**JSON**と**XML**の両形式の ALPS プロファイルをサポートしています（ファイル拡張子で自動判別）。`semantic`記述子の`title`または`doc`がパラメータの説明として使用されます。同一プロファイル内の`href="#id"`参照は自動解決され、`safe` / `unsafe` / `idempotent`（トランジション）記述子は除外されます。
 
 ## パラメータ説明の優先順位
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ $dictionary = new AlpsSemanticDictionary('/path/to/profile.json');
 $converter = new SchemaConverter($dictionary);
 ```
 
-The `title` or `doc.value` from ALPS `semantic` descriptors will be used as parameter descriptions.
+Both **JSON** and **XML** ALPS profiles are supported (format is detected from the file extension). The `title` or `doc` of `semantic` descriptors is used as the parameter description. Same-profile `href="#id"` references are resolved automatically; non-semantic descriptors (`safe` / `unsafe` / `idempotent`) are excluded.
 
 ## Parameter Description Priority
 

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,10 @@
     ],
     "require": {
         "php": "^8.2",
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "ext-simplexml": "*",
         "bear/resource": "^1.10",
-        "koriym/app-state-diagram": "^0.8 || ^0.17",
         "phpdocumentor/reflection-docblock": "^5.2 || ^6.0",
         "ray/di": "^2.18"
     },

--- a/src/Schema/AlpsSemanticDictionary.php
+++ b/src/Schema/AlpsSemanticDictionary.php
@@ -16,7 +16,9 @@ use function json_decode;
 use function pathinfo;
 use function simplexml_load_string;
 use function sprintf;
+use function str_starts_with;
 use function strtolower;
+use function substr;
 use function trim;
 
 use const JSON_THROW_ON_ERROR;
@@ -28,22 +30,31 @@ use const PATHINFO_EXTENSION;
  * Parses an ALPS profile (JSON or XML) and exposes an
  * `id` => description mapping for semantic descriptors.
  *
+ * Behavior matches koriym/app-state-diagram for the subset we need:
+ *  - Only `type === 'semantic'` descriptors are included (transitions excluded).
+ *  - Same-profile `href="#id"` references resolve to the referenced description.
+ *  - Cross-file href references are not supported.
+ *
+ * @phpstan-type Entry array{id: string, type: string, description: string|null, href: string|null}
  * @extends ArrayObject<string, string>
  */
 final class AlpsSemanticDictionary extends ArrayObject
 {
+    /** Maximum href chain depth (e.g. A -> B -> C). Guards against cycles. */
+    private const HREF_RESOLUTION_DEPTH = 10;
+
     public function __construct(string $profilePath)
     {
         $extension = strtolower(pathinfo($profilePath, PATHINFO_EXTENSION));
-        $dictionary = match ($extension) {
-            'json' => $this->loadJson($profilePath),
-            'xml' => $this->loadXml($profilePath),
+        $entries = match ($extension) {
+            'json' => $this->parseJson($profilePath),
+            'xml' => $this->parseXml($profilePath),
             default => throw new InvalidArgumentException(
                 sprintf('Unsupported ALPS profile format: .%s', $extension),
             ),
         };
 
-        parent::__construct($dictionary);
+        parent::__construct($this->buildDictionary($entries));
     }
 
     public function get(string $key): string|null
@@ -51,8 +62,75 @@ final class AlpsSemanticDictionary extends ArrayObject
         return $this[$key] ?? null;
     }
 
-    /** @return array<string, string> */
-    private function loadJson(string $path): array
+    /**
+     * @param list<Entry> $entries
+     *
+     * @return array<string, string>
+     */
+    private function buildDictionary(array $entries): array
+    {
+        $semanticEntries = [];
+        foreach ($entries as $entry) {
+            if ($entry['type'] !== 'semantic') {
+                continue;
+            }
+
+            $semanticEntries[] = $entry;
+        }
+
+        $dictionary = [];
+        foreach ($semanticEntries as $entry) {
+            if ($entry['description'] === null) {
+                continue;
+            }
+
+            $dictionary[$entry['id']] = $entry['description'];
+        }
+
+        for ($depth = 0; $depth < self::HREF_RESOLUTION_DEPTH; $depth++) {
+            if (! $this->resolveHrefPass($semanticEntries, $dictionary)) {
+                break;
+            }
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * @param list<Entry>           $semanticEntries
+     * @param array<string, string> $dictionary
+     */
+    private function resolveHrefPass(array $semanticEntries, array &$dictionary): bool
+    {
+        $changed = false;
+        foreach ($semanticEntries as $entry) {
+            if (isset($dictionary[$entry['id']])) {
+                continue;
+            }
+
+            $href = $entry['href'];
+            if ($href === null) {
+                continue;
+            }
+
+            if (! str_starts_with($href, '#')) {
+                continue;
+            }
+
+            $referencedId = substr($href, 1);
+            if (! isset($dictionary[$referencedId])) {
+                continue;
+            }
+
+            $dictionary[$entry['id']] = $dictionary[$referencedId];
+            $changed = true;
+        }
+
+        return $changed;
+    }
+
+    /** @return list<Entry> */
+    private function parseJson(string $path): array
     {
         /** @var mixed $data */
         $data = json_decode((string) file_get_contents($path), false, 512, JSON_THROW_ON_ERROR);
@@ -60,27 +138,27 @@ final class AlpsSemanticDictionary extends ArrayObject
         $alps = $data instanceof stdClass ? ($data->alps ?? null) : null;
         /** @var list<stdClass>|stdClass $descriptors */
         $descriptors = $alps instanceof stdClass ? ($alps->descriptor ?? []) : [];
-        $dictionary = [];
-        $this->walkJson($descriptors, $dictionary);
+        $entries = [];
+        $this->walkJson($descriptors, $entries);
 
-        return $dictionary;
+        return $entries;
     }
 
     /**
      * @param list<stdClass>|stdClass $descriptors
-     * @param array<string, string>   $dictionary
+     * @param list<Entry>             $entries
      */
-    private function walkJson(array|stdClass $descriptors, array &$dictionary): void
+    private function walkJson(array|stdClass $descriptors, array &$entries): void
     {
         $list = is_array($descriptors) ? $descriptors : [$descriptors];
         foreach ($list as $descriptor) {
-            if (! isset($descriptor->id)) {
-                continue;
-            }
-
-            $description = $this->extractJsonDescription($descriptor);
-            if ($description !== null) {
-                $dictionary[(string) $descriptor->id] = $description;
+            if (isset($descriptor->id)) {
+                $entries[] = [
+                    'id' => (string) $descriptor->id,
+                    'type' => isset($descriptor->type) ? (string) $descriptor->type : 'semantic',
+                    'description' => $this->extractJsonDescription($descriptor),
+                    'href' => isset($descriptor->href) ? (string) $descriptor->href : null,
+                ];
             }
 
             if (! isset($descriptor->descriptor)) {
@@ -89,7 +167,7 @@ final class AlpsSemanticDictionary extends ArrayObject
 
             /** @var list<stdClass>|stdClass $nested */
             $nested = $descriptor->descriptor;
-            $this->walkJson($nested, $dictionary);
+            $this->walkJson($nested, $entries);
         }
     }
 
@@ -112,40 +190,40 @@ final class AlpsSemanticDictionary extends ArrayObject
         return null;
     }
 
-    /** @return array<string, string> */
-    private function loadXml(string $path): array
+    /** @return list<Entry> */
+    private function parseXml(string $path): array
     {
         $xml = simplexml_load_string((string) file_get_contents($path));
         if ($xml === false) {
             throw new InvalidArgumentException(sprintf('Failed to parse ALPS XML profile: %s', $path));
         }
 
-        $dictionary = [];
+        $entries = [];
         /** @psalm-suppress PossiblyNullArgument */
-        $this->walkXml($xml->descriptor, $dictionary);
+        $this->walkXml($xml->descriptor, $entries);
 
-        return $dictionary;
+        return $entries;
     }
 
-    /** @param array<string, string> $dictionary */
-    private function walkXml(SimpleXMLElement $descriptors, array &$dictionary): void
+    /** @param list<Entry> $entries */
+    private function walkXml(SimpleXMLElement $descriptors, array &$entries): void
     {
         foreach ($descriptors as $descriptor) {
             $id = (string) ($descriptor['id'] ?? '');
-            if ($id === '') {
-                continue;
-            }
-
-            $description = $this->extractXmlDescription($descriptor);
-            if ($description !== null) {
-                $dictionary[$id] = $description;
+            if ($id !== '') {
+                $entries[] = [
+                    'id' => $id,
+                    'type' => (string) ($descriptor['type'] ?? 'semantic'),
+                    'description' => $this->extractXmlDescription($descriptor),
+                    'href' => isset($descriptor['href']) ? (string) $descriptor['href'] : null,
+                ];
             }
 
             if (! isset($descriptor->descriptor)) {
                 continue;
             }
 
-            $this->walkXml($descriptor->descriptor, $dictionary);
+            $this->walkXml($descriptor->descriptor, $entries);
         }
     }
 

--- a/src/Schema/AlpsSemanticDictionary.php
+++ b/src/Schema/AlpsSemanticDictionary.php
@@ -5,58 +5,164 @@ declare(strict_types=1);
 namespace BEAR\ToolUse\Schema;
 
 use ArrayObject;
-use Koriym\AppStateDiagram\Profile;
-use Koriym\AppStateDiagram\SemanticDescriptor;
+use InvalidArgumentException;
+use SimpleXMLElement;
 use stdClass;
 
+use function file_get_contents;
+use function is_array;
 use function is_string;
+use function json_decode;
+use function pathinfo;
+use function simplexml_load_string;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+use const JSON_THROW_ON_ERROR;
+use const PATHINFO_EXTENSION;
 
 /**
  * ALPS semantic dictionary for description enrichment
+ *
+ * Parses an ALPS profile (JSON or XML) and exposes an
+ * `id` => description mapping for semantic descriptors.
  *
  * @extends ArrayObject<string, string>
  */
 final class AlpsSemanticDictionary extends ArrayObject
 {
-    public function __construct(Profile $profile)
+    public function __construct(string $profilePath)
     {
-        $dictionary = [];
-        foreach ($profile->descriptors as $descriptor) {
-            if (! $descriptor instanceof SemanticDescriptor) {
-                continue; // @codeCoverageIgnore
-            }
-
-            $description = $this->extractDescription($descriptor);
-            if ($description === null) {
-                continue;
-            }
-
-            $dictionary[$descriptor->id] = $description;
-        }
+        $extension = strtolower(pathinfo($profilePath, PATHINFO_EXTENSION));
+        $dictionary = match ($extension) {
+            'json' => $this->loadJson($profilePath),
+            'xml' => $this->loadXml($profilePath),
+            default => throw new InvalidArgumentException(
+                sprintf('Unsupported ALPS profile format: .%s', $extension),
+            ),
+        };
 
         parent::__construct($dictionary);
-    }
-
-    private function extractDescription(SemanticDescriptor $descriptor): string|null
-    {
-        if ($descriptor->title !== '') {
-            return $descriptor->title;
-        }
-
-        // v0.17+ stores doc as string, v0.8 stores as stdClass with value property
-        if (is_string($descriptor->doc) && $descriptor->doc !== '') {
-            return $descriptor->doc;
-        }
-
-        if ($descriptor->doc instanceof stdClass && isset($descriptor->doc->value)) {
-            return (string) $descriptor->doc->value;
-        }
-
-        return null;
     }
 
     public function get(string $key): string|null
     {
         return $this[$key] ?? null;
+    }
+
+    /** @return array<string, string> */
+    private function loadJson(string $path): array
+    {
+        /** @var mixed $data */
+        $data = json_decode((string) file_get_contents($path), false, 512, JSON_THROW_ON_ERROR);
+        /** @var mixed $alps */
+        $alps = $data instanceof stdClass ? ($data->alps ?? null) : null;
+        /** @var list<stdClass>|stdClass $descriptors */
+        $descriptors = $alps instanceof stdClass ? ($alps->descriptor ?? []) : [];
+        $dictionary = [];
+        $this->walkJson($descriptors, $dictionary);
+
+        return $dictionary;
+    }
+
+    /**
+     * @param list<stdClass>|stdClass $descriptors
+     * @param array<string, string>   $dictionary
+     */
+    private function walkJson(array|stdClass $descriptors, array &$dictionary): void
+    {
+        $list = is_array($descriptors) ? $descriptors : [$descriptors];
+        foreach ($list as $descriptor) {
+            if (! isset($descriptor->id)) {
+                continue;
+            }
+
+            $description = $this->extractJsonDescription($descriptor);
+            if ($description !== null) {
+                $dictionary[(string) $descriptor->id] = $description;
+            }
+
+            if (! isset($descriptor->descriptor)) {
+                continue;
+            }
+
+            /** @var list<stdClass>|stdClass $nested */
+            $nested = $descriptor->descriptor;
+            $this->walkJson($nested, $dictionary);
+        }
+    }
+
+    private function extractJsonDescription(stdClass $descriptor): string|null
+    {
+        if (isset($descriptor->title) && $descriptor->title !== '') {
+            return (string) $descriptor->title;
+        }
+
+        /** @var mixed $doc */
+        $doc = $descriptor->doc ?? null;
+        if (is_string($doc) && $doc !== '') {
+            return $doc;
+        }
+
+        if ($doc instanceof stdClass && isset($doc->value) && $doc->value !== '') {
+            return (string) $doc->value;
+        }
+
+        return null;
+    }
+
+    /** @return array<string, string> */
+    private function loadXml(string $path): array
+    {
+        $xml = simplexml_load_string((string) file_get_contents($path));
+        if ($xml === false) {
+            throw new InvalidArgumentException(sprintf('Failed to parse ALPS XML profile: %s', $path));
+        }
+
+        $dictionary = [];
+        /** @psalm-suppress PossiblyNullArgument */
+        $this->walkXml($xml->descriptor, $dictionary);
+
+        return $dictionary;
+    }
+
+    /** @param array<string, string> $dictionary */
+    private function walkXml(SimpleXMLElement $descriptors, array &$dictionary): void
+    {
+        foreach ($descriptors as $descriptor) {
+            $id = (string) ($descriptor['id'] ?? '');
+            if ($id === '') {
+                continue;
+            }
+
+            $description = $this->extractXmlDescription($descriptor);
+            if ($description !== null) {
+                $dictionary[$id] = $description;
+            }
+
+            if (! isset($descriptor->descriptor)) {
+                continue;
+            }
+
+            $this->walkXml($descriptor->descriptor, $dictionary);
+        }
+    }
+
+    private function extractXmlDescription(SimpleXMLElement $descriptor): string|null
+    {
+        $title = (string) ($descriptor['title'] ?? '');
+        if ($title !== '') {
+            return $title;
+        }
+
+        if (isset($descriptor->doc)) {
+            $doc = trim((string) $descriptor->doc);
+            if ($doc !== '') {
+                return $doc;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Schema/AlpsSemanticDictionary.php
+++ b/src/Schema/AlpsSemanticDictionary.php
@@ -6,13 +6,19 @@ namespace BEAR\ToolUse\Schema;
 
 use ArrayObject;
 use InvalidArgumentException;
+use JsonException;
 use SimpleXMLElement;
 use stdClass;
 
+use function array_map;
 use function file_get_contents;
+use function implode;
 use function is_array;
 use function is_string;
 use function json_decode;
+use function libxml_clear_errors;
+use function libxml_get_errors;
+use function libxml_use_internal_errors;
 use function pathinfo;
 use function simplexml_load_string;
 use function sprintf;
@@ -132,8 +138,19 @@ final class AlpsSemanticDictionary extends ArrayObject
     /** @return list<Entry> */
     private function parseJson(string $path): array
     {
-        /** @var mixed $data */
-        $data = json_decode((string) file_get_contents($path), false, 512, JSON_THROW_ON_ERROR);
+        $contents = $this->readProfile($path);
+
+        try {
+            /** @var mixed $data */
+            $data = json_decode($contents, false, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidArgumentException(
+                sprintf('Failed to parse ALPS JSON profile %s: %s', $path, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
         /** @var mixed $alps */
         $alps = $data instanceof stdClass ? ($data->alps ?? null) : null;
         /** @var list<stdClass>|stdClass $descriptors */
@@ -193,9 +210,26 @@ final class AlpsSemanticDictionary extends ArrayObject
     /** @return list<Entry> */
     private function parseXml(string $path): array
     {
-        $xml = simplexml_load_string((string) file_get_contents($path));
-        if ($xml === false) {
-            throw new InvalidArgumentException(sprintf('Failed to parse ALPS XML profile: %s', $path));
+        $contents = $this->readProfile($path);
+
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $xml = simplexml_load_string($contents);
+            if ($xml === false) {
+                $errors = array_map(
+                    static fn (object $error): string => trim($error->message),
+                    libxml_get_errors(),
+                );
+                libxml_clear_errors();
+
+                throw new InvalidArgumentException(sprintf(
+                    'Failed to parse ALPS XML profile %s: %s',
+                    $path,
+                    implode('; ', $errors),
+                ));
+            }
+        } finally {
+            libxml_use_internal_errors($previous);
         }
 
         $entries = [];
@@ -203,6 +237,16 @@ final class AlpsSemanticDictionary extends ArrayObject
         $this->walkXml($xml->descriptor, $entries);
 
         return $entries;
+    }
+
+    private function readProfile(string $path): string
+    {
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            throw new InvalidArgumentException(sprintf('Unable to read ALPS profile: %s', $path));
+        }
+
+        return $contents;
     }
 
     /** @param list<Entry> $entries */

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -23,6 +23,17 @@
       {
         "id": "email",
         "type": "semantic"
+      },
+      {
+        "id": "user",
+        "type": "semantic",
+        "descriptor": [
+          {
+            "id": "nestedField",
+            "type": "semantic",
+            "doc": "Nested description"
+          }
+        ]
       }
     ]
   }

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -59,6 +59,11 @@
         "id": "chainB",
         "type": "semantic",
         "href": "#userId"
+      },
+      {
+        "id": "externalRef",
+        "type": "semantic",
+        "href": "https://example.com/profile.json#userId"
       }
     ]
   }

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -34,6 +34,31 @@
             "doc": "Nested description"
           }
         ]
+      },
+      {
+        "id": "createUser",
+        "type": "safe",
+        "title": "Create user transition"
+      },
+      {
+        "id": "userIdAlias",
+        "type": "semantic",
+        "href": "#userId"
+      },
+      {
+        "id": "danglingHref",
+        "type": "semantic",
+        "href": "#nonExistent"
+      },
+      {
+        "id": "chainA",
+        "type": "semantic",
+        "href": "#chainB"
+      },
+      {
+        "id": "chainB",
+        "type": "semantic",
+        "href": "#userId"
       }
     ]
   }

--- a/tests/Fake/alps-profile.xml
+++ b/tests/Fake/alps-profile.xml
@@ -11,4 +11,9 @@
       <doc>Nested description</doc>
     </descriptor>
   </descriptor>
+  <descriptor id="createUser" type="safe" title="Create user transition"/>
+  <descriptor id="userIdAlias" type="semantic" href="#userId"/>
+  <descriptor id="danglingHref" type="semantic" href="#nonExistent"/>
+  <descriptor id="chainA" type="semantic" href="#chainB"/>
+  <descriptor id="chainB" type="semantic" href="#userId"/>
 </alps>

--- a/tests/Fake/alps-profile.xml
+++ b/tests/Fake/alps-profile.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alps>
+  <descriptor id="id" type="semantic" title="Resource identifier"/>
+  <descriptor id="userId" type="semantic" title="User identifier"/>
+  <descriptor id="userName" type="semantic">
+    <doc>Name of the user</doc>
+  </descriptor>
+  <descriptor id="email" type="semantic"/>
+  <descriptor id="user" type="semantic">
+    <descriptor id="nestedField" type="semantic">
+      <doc>Nested description</doc>
+    </descriptor>
+  </descriptor>
+</alps>

--- a/tests/Fake/alps-profile.xml
+++ b/tests/Fake/alps-profile.xml
@@ -16,4 +16,5 @@
   <descriptor id="danglingHref" type="semantic" href="#nonExistent"/>
   <descriptor id="chainA" type="semantic" href="#chainB"/>
   <descriptor id="chainB" type="semantic" href="#userId"/>
+  <descriptor id="externalRef" type="semantic" href="https://example.com/profile.xml#userId"/>
 </alps>

--- a/tests/Fake/invalid-alps.json
+++ b/tests/Fake/invalid-alps.json
@@ -1,0 +1,1 @@
+{ not valid json

--- a/tests/Fake/invalid-alps.xml
+++ b/tests/Fake/invalid-alps.xml
@@ -1,0 +1,1 @@
+<not valid xml

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -80,6 +80,12 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertSame('User identifier', $this->dictionary->get('chainB'));
     }
 
+    public function testCrossFileHrefIsIgnored(): void
+    {
+        // href that does not start with '#' is not resolved (cross-file ref unsupported)
+        $this->assertNull($this->dictionary->get('externalRef'));
+    }
+
     public function testLoadXmlProfile(): void
     {
         $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.xml');

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -8,8 +8,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-use function libxml_use_internal_errors;
-
 #[CoversClass(AlpsSemanticDictionary::class)]
 final class AlpsSemanticDictionaryTest extends TestCase
 {
@@ -99,6 +97,7 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertSame('User identifier', $dictionary->get('userIdAlias'));
         $this->assertNull($dictionary->get('danglingHref'));
         $this->assertSame('User identifier', $dictionary->get('chainA'));
+        $this->assertNull($dictionary->get('externalRef'));
     }
 
     public function testUnsupportedExtensionThrows(): void
@@ -112,13 +111,32 @@ final class AlpsSemanticDictionaryTest extends TestCase
     public function testInvalidXmlThrows(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Failed to parse ALPS XML profile/');
+        $this->expectExceptionMessageMatches('/Failed to parse ALPS XML profile .*: .+/');
 
-        $previous = libxml_use_internal_errors(true);
-        try {
-            new AlpsSemanticDictionary(__DIR__ . '/../Fake/invalid-alps.xml');
-        } finally {
-            libxml_use_internal_errors($previous);
-        }
+        new AlpsSemanticDictionary(__DIR__ . '/../Fake/invalid-alps.xml');
+    }
+
+    public function testInvalidJsonThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Failed to parse ALPS JSON profile/');
+
+        new AlpsSemanticDictionary(__DIR__ . '/../Fake/invalid-alps.json');
+    }
+
+    public function testMissingJsonFileThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Unable to read ALPS profile/');
+
+        new AlpsSemanticDictionary(__DIR__ . '/../Fake/no-such-file.json');
+    }
+
+    public function testMissingXmlFileThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Unable to read ALPS profile/');
+
+        new AlpsSemanticDictionary(__DIR__ . '/../Fake/no-such-file.xml');
     }
 }

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -55,6 +55,31 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertSame('Nested description', $this->dictionary->get('nestedField'));
     }
 
+    public function testNonSemanticDescriptorIsExcluded(): void
+    {
+        // createUser is type=safe (transition) — must NOT appear in dictionary
+        $this->assertNull($this->dictionary->get('createUser'));
+    }
+
+    public function testLocalHrefResolvesToReferencedDescription(): void
+    {
+        // userIdAlias has href="#userId" → resolves to "User identifier"
+        $this->assertSame('User identifier', $this->dictionary->get('userIdAlias'));
+    }
+
+    public function testDanglingHrefIsSkipped(): void
+    {
+        // danglingHref references a non-existent id — left out of dictionary
+        $this->assertNull($this->dictionary->get('danglingHref'));
+    }
+
+    public function testHrefChainResolvesAcrossMultipleHops(): void
+    {
+        // chainA -> chainB -> userId
+        $this->assertSame('User identifier', $this->dictionary->get('chainA'));
+        $this->assertSame('User identifier', $this->dictionary->get('chainB'));
+    }
+
     public function testLoadXmlProfile(): void
     {
         $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.xml');
@@ -64,6 +89,10 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertSame('Name of the user', $dictionary->get('userName'));
         $this->assertNull($dictionary->get('email'));
         $this->assertSame('Nested description', $dictionary->get('nestedField'));
+        $this->assertNull($dictionary->get('createUser'));
+        $this->assertSame('User identifier', $dictionary->get('userIdAlias'));
+        $this->assertNull($dictionary->get('danglingHref'));
+        $this->assertSame('User identifier', $dictionary->get('chainA'));
     }
 
     public function testUnsupportedExtensionThrows(): void

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Schema;
 
-use Koriym\AppStateDiagram\LabelNameTitle;
-use Koriym\AppStateDiagram\Profile;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+
+use function libxml_use_internal_errors;
 
 #[CoversClass(AlpsSemanticDictionary::class)]
 final class AlpsSemanticDictionaryTest extends TestCase
@@ -16,9 +17,7 @@ final class AlpsSemanticDictionaryTest extends TestCase
 
     protected function setUp(): void
     {
-        $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $this->dictionary = new AlpsSemanticDictionary($profile);
+        $this->dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
     }
 
     public function testGetWithTitle(): void
@@ -48,5 +47,43 @@ final class AlpsSemanticDictionaryTest extends TestCase
     {
         $this->assertSame('User identifier', $this->dictionary['userId']);
         $this->assertNull($this->dictionary['nonexistent'] ?? null);
+    }
+
+    public function testNestedDescriptorFromJson(): void
+    {
+        // nestedField is under user.descriptor with a string doc
+        $this->assertSame('Nested description', $this->dictionary->get('nestedField'));
+    }
+
+    public function testLoadXmlProfile(): void
+    {
+        $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.xml');
+
+        $this->assertSame('Resource identifier', $dictionary->get('id'));
+        $this->assertSame('User identifier', $dictionary->get('userId'));
+        $this->assertSame('Name of the user', $dictionary->get('userName'));
+        $this->assertNull($dictionary->get('email'));
+        $this->assertSame('Nested description', $dictionary->get('nestedField'));
+    }
+
+    public function testUnsupportedExtensionThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported ALPS profile format: .yaml');
+
+        new AlpsSemanticDictionary(__DIR__ . '/../Fake/profile.yaml');
+    }
+
+    public function testInvalidXmlThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Failed to parse ALPS XML profile/');
+
+        $previous = libxml_use_internal_errors(true);
+        try {
+            new AlpsSemanticDictionary(__DIR__ . '/../Fake/invalid-alps.xml');
+        } finally {
+            libxml_use_internal_errors($previous);
+        }
     }
 }

--- a/tests/Schema/ParameterDescriptionResolverTest.php
+++ b/tests/Schema/ParameterDescriptionResolverTest.php
@@ -10,8 +10,6 @@ use BEAR\ToolUse\Fake\Resource\App\FakeJsonSchemaResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeMissingParamDocResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeSnakeCaseResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeUserResource;
-use Koriym\AppStateDiagram\LabelNameTitle;
-use Koriym\AppStateDiagram\Profile;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -37,9 +35,7 @@ final class ParameterDescriptionResolverTest extends TestCase
     public function testResolveFromAlpsDictionary(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
-        $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
         $resolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
 
         $reflection = new ReflectionClass(FakeUserResource::class);
@@ -54,9 +50,7 @@ final class ParameterDescriptionResolverTest extends TestCase
     public function testPhpDocTakesPriorityOverAlps(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
-        $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
         $resolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
 
         // FakeDocParamResource has @param for "id", ALPS also has "id" descriptor
@@ -73,9 +67,7 @@ final class ParameterDescriptionResolverTest extends TestCase
     public function testSnakeCaseToCamelCaseForAlps(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
-        $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
         $resolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
 
         $reflection = new ReflectionClass(FakeSnakeCaseResource::class);
@@ -170,9 +162,7 @@ final class ParameterDescriptionResolverTest extends TestCase
     public function testFallsBackToAlpsWhenNoPhpDoc(): void
     {
         $docBlockFactory = DocBlockFactory::createInstance();
-        $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
         $resolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
 
         // FakeUserResource::onGet has no PHPDoc, so should fall back to ALPS

--- a/tests/Schema/SchemaConverterTest.php
+++ b/tests/Schema/SchemaConverterTest.php
@@ -16,8 +16,6 @@ use BEAR\ToolUse\Fake\Resource\App\FakeSnakeCaseResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeTypesResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeUnionTypeResource;
 use BEAR\ToolUse\Fake\Resource\App\FakeUserResource;
-use Koriym\AppStateDiagram\LabelNameTitle;
-use Koriym\AppStateDiagram\Profile;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -205,8 +203,7 @@ final class SchemaConverterTest extends TestCase
     {
         $docBlockFactory = DocBlockFactory::createInstance();
         $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary($profilePath);
         $descriptionResolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
         $converter = new SchemaConverter($docBlockFactory, $descriptionResolver);
 
@@ -241,8 +238,7 @@ final class SchemaConverterTest extends TestCase
     {
         $docBlockFactory = DocBlockFactory::createInstance();
         $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary($profilePath);
         $descriptionResolver = new ParameterDescriptionResolver($docBlockFactory, null, $dictionary);
         $converter = new SchemaConverter($docBlockFactory, $descriptionResolver);
 
@@ -332,8 +328,7 @@ final class SchemaConverterTest extends TestCase
     {
         $docBlockFactory = DocBlockFactory::createInstance();
         $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary($profilePath);
         $jsonSchemaRepository = new JsonSchemaRepository(__DIR__ . '/../Fake/json_schema');
         $descriptionResolver = new ParameterDescriptionResolver($docBlockFactory, $jsonSchemaRepository, $dictionary);
 
@@ -354,8 +349,7 @@ final class SchemaConverterTest extends TestCase
     {
         $docBlockFactory = DocBlockFactory::createInstance();
         $profilePath = __DIR__ . '/../Fake/alps-profile.json';
-        $profile = new Profile($profilePath, new LabelNameTitle());
-        $dictionary = new AlpsSemanticDictionary($profile);
+        $dictionary = new AlpsSemanticDictionary($profilePath);
         $jsonSchemaRepository = new JsonSchemaRepository(__DIR__ . '/../Fake/json_schema');
         $descriptionResolver = new ParameterDescriptionResolver($docBlockFactory, $jsonSchemaRepository, $dictionary);
 


### PR DESCRIPTION
## Summary

- BEAR.ToolUse only used 3 properties from `koriym/app-state-diagram` (`Profile->descriptors`, `SemanticDescriptor->id|title|doc`), yet that dependency pulled in **~12MB** of code plus 4 transitive packages (`koriym/data-file`, `michelf/php-markdown`, `seld/jsonlint`, `symfony/polyfill-php81`).
- Replace the dependency with a self-contained JSON + XML ALPS parser inside `AlpsSemanticDictionary` (~240 lines).
- Eliminates the awkward `^0.8 || ^0.17` version constraint that excluded intermediate releases.

## Breaking change

`AlpsSemanticDictionary` now takes a profile file path directly instead of a `Koriym\AppStateDiagram\Profile` instance.

```php
// Before
$profile    = new Profile($path, new LabelNameTitle());
$dictionary = new AlpsSemanticDictionary($profile);

// After
$dictionary = new AlpsSemanticDictionary($path);
```

## What the new parser supports

- **JSON and XML** ALPS profiles (auto-detected from file extension)
- **Nested `descriptor`** walked recursively
- **`title`** and both **`doc`** shapes (string in v1.0, `{value: ...}` in older v0.8 style)
- **`type === 'semantic'` filter** — `safe` / `unsafe` / `idempotent` transition descriptors are excluded, matching the original `instanceof SemanticDescriptor` behavior
- **Same-profile `href="#id"` resolution**, including multi-hop chains (depth-capped at 10 to guard against cycles)
- Throws `InvalidArgumentException` for unsupported extensions and malformed XML

### Intentionally not supported

- Cross-file `href` (e.g. `other.json#id`) — left out for the single-profile vocabulary-dictionary use case
- XSD schema validation (ASD uses `koriym/xml-loader` for this; not needed here)
- Markdown rendering of `doc` content — we emit the raw text, same as ASD

## Architecture

Two-phase pipeline to keep format parsing and dictionary logic cleanly separated:

1. `parseJson` / `parseXml` → intermediate `list<Entry>` where `Entry = {id, type, description, href}`
2. `buildDictionary` → apply the `type === 'semantic'` filter, then resolve `href` references (`resolveHrefPass` per iteration)

## Test plan

- [x] `composer cs` — 0 errors (56 files)
- [x] `composer phpmd` — 0 issues
- [x] `composer sa` (Psalm) — no errors
- [x] `composer test` — **184 tests, 401 assertions** passing
- [x] **Coverage: 100.00%** (626/626 lines, 109/109 methods) verified locally with Xdebug
- [x] Added XML fixture (`tests/Fake/alps-profile.xml`) and invalid-XML fixture
- [x] New tests cover: nested descriptors, XML loading, unsupported extension throw, invalid-XML throw, `type=safe` exclusion, local `href` resolution, dangling `href`, href chain (A→B→C), cross-file href ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
