### PR TITLE
Add ToolCallObserver hook to Dispatcher for tool call observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.0] - Unreleased
 
 ### Added
+- `ToolCallObserverInterface` invoked once per `Dispatcher` dispatch (success, status>=400, exception, unknown tool) with `ToolCall`, `ToolResult` (post-filter), and elapsed `durationMs`. `ToolUseModule` binds `NullToolCallObserver` (no-op) by default; applications can override the binding to plug in audit logging, metrics, or latency tracking.
 - Resource classes as AI agent tools via `#[Tool]` attribute
 - `#[Exclude]` attribute to exclude methods/classes from tool exposure
 - `#[Tool(confirm: true)]` for human-in-the-loop confirmation on destructive operations

--- a/README.ja.md
+++ b/README.ja.md
@@ -375,6 +375,51 @@ class Article extends ResourceObject
 
 フィルタは成功レスポンスにのみ適用されます。エラーレスポンス（ステータスコード >= 400）はフィルタされずにそのまま送信されます。
 
+## ツール呼び出しの観測
+
+すべてのツール呼び出しをフックして、監査ログ・メトリクス・レイテンシ計測などを行えます。Observer はディスパッチごとに 1 回だけ呼び出され、成功・ステータスコードエラー・例外・未知ツールのどの経路でも `ToolCall`、`ToolResult`、経過時間（ミリ秒）を受け取ります。
+
+### Observer の実装
+
+```php
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolCallObserverInterface;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use Override;
+
+final readonly class AuditLogObserver implements ToolCallObserverInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    #[Override]
+    public function observe(ToolCall $toolCall, ToolResult $result, float $durationMs): void
+    {
+        $this->logger->info('tool_call', [
+            'name' => $toolCall->name,
+            'input' => $toolCall->input,
+            'isError' => $result->isError,
+            'durationMs' => $durationMs,
+        ]);
+    }
+}
+```
+
+### DI モジュールでバインド
+
+```php
+$this->bind(ToolCallObserverInterface::class)->to(AuditLogObserver::class);
+```
+
+Observer がバインドされていない場合、デフォルトで `NullToolCallObserver`（no-op）が使用されます。
+
+### 設計上の補足
+
+- Observer に渡される `ToolResult` はレスポンスフィルタ適用**後**のもの、つまり LLM が実際に受け取る形です。
+- インターフェイスは意図的に最小限です。スレッドID／会話ID／ユーザーIDなどアプリケーション固有のコンテキストは、利用者側のステートフルな Observer 実装で扱うべきです（インターフェイス引数には含めません）。
+- `Dispatcher` は分岐に関わらず、ディスパッチごとに必ず 1 回 Observer を呼び出します。
+
 ## JSON Schemaの統合
 
 BEAR.ResourceのJSON Schemaを使用してパラメータ定義を強化できます。
@@ -521,6 +566,7 @@ Dispatcherが検出するエラー:
 | `StreamingAgentInterface` | ストリーミングエージェントランタイム |
 | `ToolResultFilterInterface` | LLM送信前のレスポンスフィルタ |
 | `ConfirmationHandlerInterface` | 破壊的ツールのユーザー確認 |
+| `ToolCallObserverInterface` | ディスパッチごとに 1 回呼ばれるフック（監査・メトリクス・レイテンシ計測） |
 
 ### 主要クラス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -406,6 +406,8 @@ final readonly class AuditLogObserver implements ToolCallObserverInterface
 }
 ```
 
+> **Note:** `$toolCall->input` や `$result->content` には、利用するリソース次第で機密情報（個人情報、認証情報、API トークンなど）が含まれる可能性があります。永続ログ・トレース・外部システムへ送る前に、該当フィールドのサニタイズ／マスキングを行ってください。
+
 ### DI モジュールでバインド
 
 ```php

--- a/README.ja.md
+++ b/README.ja.md
@@ -419,6 +419,8 @@ Observer がバインドされていない場合、デフォルトで `NullToolC
 - Observer に渡される `ToolResult` はレスポンスフィルタ適用**後**のもの、つまり LLM が実際に受け取る形です。
 - インターフェイスは意図的に最小限です。スレッドID／会話ID／ユーザーIDなどアプリケーション固有のコンテキストは、利用者側のステートフルな Observer 実装で扱うべきです（インターフェイス引数には含めません）。
 - `Dispatcher` は分岐に関わらず、ディスパッチごとに必ず 1 回 Observer を呼び出します。
+- **キャンセルされたツール呼び出しは Dispatcher を経由しません。** 確認拒否は `Agent` / `StreamingAgent` 層（`ConfirmationHandlerInterface` または `Generator::send(false)`）で処理され、`Dispatcher::dispatch()` を呼ばずに `ToolResult::cancelled()` を返します。そのため Observer はキャンセル時には**呼び出されません**。
+- **`observe()` から throw された例外は `Dispatcher::dispatch()` の外へ伝播します。** 観測の失敗でツール呼び出しを止めたくない場合、Observer 実装側で I/O を try/catch するなどして自身でエラーハンドリングする責任があります。
 
 ## JSON Schemaの統合
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ If no observer is bound, `NullToolCallObserver` (a no-op) is used by default.
 - The observer receives the `ToolResult` **after** the response filter has been applied — i.e. exactly what the LLM will see.
 - The interface is intentionally minimal. Application-level context (thread/conversation IDs, user ID, etc.) belongs in your own stateful observer implementation, not in the interface signature.
 - `Dispatcher` ensures the observer is called exactly once per dispatch, regardless of which branch produced the result.
+- **Cancelled tool calls bypass the Dispatcher entirely.** Confirmation denial is handled at the `Agent` / `StreamingAgent` layer (via `ConfirmationHandlerInterface` or `Generator::send(false)`), which returns `ToolResult::cancelled()` without calling `Dispatcher::dispatch()`. The observer is therefore **not** invoked for cancellations.
+- **Exceptions thrown from `observe()` propagate out of `Dispatcher::dispatch()`.** Observer implementations are responsible for handling their own errors (e.g. wrapping persistence calls in try/catch) if observation failures should not break tool dispatch.
 
 ## JSON Schema Integration
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ final readonly class AuditLogObserver implements ToolCallObserverInterface
 }
 ```
 
+> **Note:** `$toolCall->input` and `$result->content` may contain sensitive values (PII, credentials, API tokens) depending on the underlying resource. Sanitize or redact such fields before writing to persistent logs, traces, or external systems.
+
 ### Bind in DI Module
 
 ```php

--- a/README.md
+++ b/README.md
@@ -375,6 +375,51 @@ class Article extends ResourceObject
 
 Filters are only applied to success responses. Error responses (status code >= 400) are sent unfiltered.
 
+## Observing Tool Calls
+
+Hook into every tool call to record audit logs, emit metrics, or measure latency. The observer is invoked once per dispatch — across success, status-code errors, exceptions, and unknown-tool paths — receiving the `ToolCall`, the `ToolResult`, and the elapsed time in milliseconds.
+
+### Implement an Observer
+
+```php
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolCallObserverInterface;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use Override;
+
+final readonly class AuditLogObserver implements ToolCallObserverInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    #[Override]
+    public function observe(ToolCall $toolCall, ToolResult $result, float $durationMs): void
+    {
+        $this->logger->info('tool_call', [
+            'name' => $toolCall->name,
+            'input' => $toolCall->input,
+            'isError' => $result->isError,
+            'durationMs' => $durationMs,
+        ]);
+    }
+}
+```
+
+### Bind in DI Module
+
+```php
+$this->bind(ToolCallObserverInterface::class)->to(AuditLogObserver::class);
+```
+
+If no observer is bound, `NullToolCallObserver` (a no-op) is used by default.
+
+### Design Notes
+
+- The observer receives the `ToolResult` **after** the response filter has been applied — i.e. exactly what the LLM will see.
+- The interface is intentionally minimal. Application-level context (thread/conversation IDs, user ID, etc.) belongs in your own stateful observer implementation, not in the interface signature.
+- `Dispatcher` ensures the observer is called exactly once per dispatch, regardless of which branch produced the result.
+
 ## JSON Schema Integration
 
 Use BEAR.Resource's JSON Schema for enhanced parameter definitions.
@@ -521,6 +566,7 @@ Errors detected by the Dispatcher:
 | `StreamingAgentInterface` | Streaming agent runtime |
 | `ToolResultFilterInterface` | Response filter before sending to LLM |
 | `ConfirmationHandlerInterface` | User confirmation for destructive tools |
+| `ToolCallObserverInterface` | Hook invoked once per tool dispatch (audit, metrics, latency) |
 
 ### Main Classes
 

--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -9,6 +9,7 @@ use BEAR\Resource\ResourceObject;
 use Override;
 use Throwable;
 
+use function hrtime;
 use function json_encode;
 use function sprintf;
 use function strtoupper;
@@ -23,15 +24,27 @@ use const JSON_UNESCAPED_UNICODE;
 final readonly class Dispatcher implements DispatcherInterface
 {
     private const ERROR_STATUS_THRESHOLD = 400;
+    private const NANOS_PER_MILLI = 1_000_000;
 
     public function __construct(
         private ResourceInterface $resource,
         private ToolRegistryInterface $registry,
+        private ToolCallObserverInterface $observer,
     ) {
     }
 
     #[Override]
     public function dispatch(ToolCall $toolCall): ToolResult
+    {
+        $startedAt = hrtime(true);
+        $result = $this->resolve($toolCall);
+        $durationMs = (hrtime(true) - $startedAt) / self::NANOS_PER_MILLI;
+        $this->observer->observe($toolCall, $result, $durationMs);
+
+        return $result;
+    }
+
+    private function resolve(ToolCall $toolCall): ToolResult
     {
         $mapping = $this->registry->get($toolCall->name);
         if ($mapping === null) {

--- a/src/Dispatch/NullToolCallObserver.php
+++ b/src/Dispatch/NullToolCallObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Dispatch;
+
+use Override;
+
+/**
+ * Default no-op observer
+ */
+final readonly class NullToolCallObserver implements ToolCallObserverInterface
+{
+    #[Override]
+    public function observe(ToolCall $toolCall, ToolResult $result, float $durationMs): void
+    {
+        // intentional no-op
+    }
+}

--- a/src/Dispatch/ToolCallObserverInterface.php
+++ b/src/Dispatch/ToolCallObserverInterface.php
@@ -12,8 +12,16 @@ interface ToolCallObserverInterface
     /**
      * Observe a single tool call invocation.
      *
-     * Called once per dispatch, after the result is determined,
-     * regardless of success/error/cancellation/unknown-tool paths.
+     * Called once per Dispatcher::dispatch(), after the (post-filter) ToolResult
+     * is determined — across success, status>=400, exception, and unknown-tool paths.
+     *
+     * The observer runs synchronously in the dispatch path. Any exception thrown
+     * propagates to the caller of dispatch(). Implementations performing I/O
+     * (audit logs, metrics, traces) are responsible for their own error handling.
+     *
+     * $durationMs measures only Dispatcher::dispatch() (registry lookup + resource
+     * invocation + filter + JSON encode); it does not include the observer call
+     * itself or any work done by the surrounding Agent loop.
      */
     public function observe(ToolCall $toolCall, ToolResult $result, float $durationMs): void;
 }

--- a/src/Dispatch/ToolCallObserverInterface.php
+++ b/src/Dispatch/ToolCallObserverInterface.php
@@ -15,6 +15,10 @@ interface ToolCallObserverInterface
      * Called once per Dispatcher::dispatch(), after the (post-filter) ToolResult
      * is determined — across success, status>=400, exception, and unknown-tool paths.
      *
+     * Note: cancelled tool calls bypass the Dispatcher entirely (handled at the
+     * Agent / StreamingAgent layer via ConfirmationHandlerInterface or generator
+     * send(false)), so this observer is not invoked for them.
+     *
      * The observer runs synchronously in the dispatch path. Any exception thrown
      * propagates to the caller of dispatch(). Implementations performing I/O
      * (audit logs, metrics, traces) are responsible for their own error handling.

--- a/src/Dispatch/ToolCallObserverInterface.php
+++ b/src/Dispatch/ToolCallObserverInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Dispatch;
+
+/**
+ * Observes tool call invocations
+ */
+interface ToolCallObserverInterface
+{
+    /**
+     * Observe a single tool call invocation.
+     *
+     * Called once per dispatch, after the result is determined,
+     * regardless of success/error/cancellation/unknown-tool paths.
+     */
+    public function observe(ToolCall $toolCall, ToolResult $result, float $durationMs): void;
+}

--- a/src/Module/ToolUseModule.php
+++ b/src/Module/ToolUseModule.php
@@ -6,6 +6,8 @@ namespace BEAR\ToolUse\Module;
 
 use BEAR\ToolUse\Dispatch\Dispatcher;
 use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolCallObserverInterface;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Dispatch\ToolRegistryInterface;
 use BEAR\ToolUse\Schema\JsonSchemaRepository;
@@ -53,6 +55,9 @@ final class ToolUseModule extends AbstractModule
 
         // Tool Collector
         $this->bind(ToolCollectorInterface::class)->to(ToolCollector::class);
+
+        // Tool Call Observer (default no-op; users can override with their own implementation)
+        $this->bind(ToolCallObserverInterface::class)->to(NullToolCallObserver::class);
 
         // Dispatcher
         $this->bind(DispatcherInterface::class)->to(Dispatcher::class);

--- a/tests/Dispatch/DispatcherTest.php
+++ b/tests/Dispatch/DispatcherTest.php
@@ -312,4 +312,19 @@ final class DispatcherTest extends TestCase
         $this->assertStringContainsString('Unknown tool', $call['result']->content);
         $this->assertGreaterThan(0.0, $call['durationMs']);
     }
+
+    public function testObserverReceivesPostFilterResult(): void
+    {
+        $this->registry->register('filtered_get', 'app://self/filtered', 'get', FakeSummaryFilter::class);
+        $toolCall = new ToolCall('call_obs_filter', 'filtered_get', ['id' => 1]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertCount(1, $this->observer->calls);
+        $call = $this->observer->calls[0];
+        $this->assertSame($result, $call['result']);
+        // Observer must see the filtered content (what the LLM sees), not the raw body.
+        $this->assertStringContainsString('"title":"Article 1"', $call['result']->content);
+        $this->assertStringNotContainsString('Long body text', $call['result']->content);
+    }
 }

--- a/tests/Dispatch/DispatcherTest.php
+++ b/tests/Dispatch/DispatcherTest.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Dispatch;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Fake\FakeSummaryFilter;
+use BEAR\ToolUse\Fake\FakeToolCallObserver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -18,6 +19,7 @@ final class DispatcherTest extends TestCase
 {
     private Dispatcher $dispatcher;
     private ToolRegistry $registry;
+    private FakeToolCallObserver $observer;
 
     protected function setUp(): void
     {
@@ -25,7 +27,8 @@ final class DispatcherTest extends TestCase
         $resource = $injector->getInstance(ResourceInterface::class);
 
         $this->registry = new ToolRegistry();
-        $this->dispatcher = new Dispatcher($resource, $this->registry);
+        $this->observer = new FakeToolCallObserver();
+        $this->dispatcher = new Dispatcher($resource, $this->registry, $this->observer);
     }
 
     public function testDispatchUnknownTool(): void
@@ -246,5 +249,67 @@ final class DispatcherTest extends TestCase
         $this->assertFalse($result->isError);
         // Without filter, body text should be present
         $this->assertStringContainsString('Long body text', $result->content);
+    }
+
+    public function testObserverInvokedOnSuccess(): void
+    {
+        $this->registry->register('crud_get', 'app://self/crud', 'get');
+        $toolCall = new ToolCall('call_obs_success', 'crud_get', ['id' => 1]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertCount(1, $this->observer->calls);
+        $call = $this->observer->calls[0];
+        $this->assertSame($toolCall, $call['toolCall']);
+        $this->assertSame($result, $call['result']);
+        $this->assertFalse($call['result']->isError);
+        $this->assertGreaterThan(0.0, $call['durationMs']);
+    }
+
+    public function testObserverInvokedOnStatusError(): void
+    {
+        $this->registry->register('status_error_get', 'app://self/status-error', 'get');
+        $toolCall = new ToolCall('call_obs_status', 'status_error_get', ['code' => 400]);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertCount(1, $this->observer->calls);
+        $call = $this->observer->calls[0];
+        $this->assertSame($toolCall, $call['toolCall']);
+        $this->assertSame($result, $call['result']);
+        $this->assertTrue($call['result']->isError);
+        $this->assertStringContainsString('400:', $call['result']->content);
+        $this->assertGreaterThan(0.0, $call['durationMs']);
+    }
+
+    public function testObserverInvokedOnException(): void
+    {
+        $this->registry->register('error_get', 'app://self/error', 'get');
+        $toolCall = new ToolCall('call_obs_exception', 'error_get', []);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertCount(1, $this->observer->calls);
+        $call = $this->observer->calls[0];
+        $this->assertSame($toolCall, $call['toolCall']);
+        $this->assertSame($result, $call['result']);
+        $this->assertTrue($call['result']->isError);
+        $this->assertStringContainsString('RuntimeException', $call['result']->content);
+        $this->assertGreaterThan(0.0, $call['durationMs']);
+    }
+
+    public function testObserverInvokedOnUnknownTool(): void
+    {
+        $toolCall = new ToolCall('call_obs_unknown', 'unknown_tool', []);
+
+        $result = $this->dispatcher->dispatch($toolCall);
+
+        $this->assertCount(1, $this->observer->calls);
+        $call = $this->observer->calls[0];
+        $this->assertSame($toolCall, $call['toolCall']);
+        $this->assertSame($result, $call['result']);
+        $this->assertTrue($call['result']->isError);
+        $this->assertStringContainsString('Unknown tool', $call['result']->content);
+        $this->assertGreaterThan(0.0, $call['durationMs']);
     }
 }

--- a/tests/Dispatch/NullToolCallObserverTest.php
+++ b/tests/Dispatch/NullToolCallObserverTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Dispatch;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NullToolCallObserver::class)]
+final class NullToolCallObserverTest extends TestCase
+{
+    public function testObserveIsNoop(): void
+    {
+        $observer = new NullToolCallObserver();
+        $toolCall = new ToolCall('call_null', 'noop', []);
+        $result = ToolResult::success('call_null', '{}');
+
+        $observer->observe($toolCall, $result, 1.5);
+
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/tests/Fake/FakeToolCallObserver.php
+++ b/tests/Fake/FakeToolCallObserver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolCallObserverInterface;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use Override;
+
+/**
+ * Fake observer that records every observed tool call for assertions.
+ */
+final class FakeToolCallObserver implements ToolCallObserverInterface
+{
+    /** @var list<array{toolCall: ToolCall, result: ToolResult, durationMs: float}> */
+    public array $calls = [];
+
+    #[Override]
+    public function observe(ToolCall $toolCall, ToolResult $result, float $durationMs): void
+    {
+        $this->calls[] = [
+            'toolCall' => $toolCall,
+            'result' => $result,
+            'durationMs' => $durationMs,
+        ];
+    }
+}

--- a/tests/Module/ToolUseModuleTest.php
+++ b/tests/Module/ToolUseModuleTest.php
@@ -7,6 +7,8 @@ namespace BEAR\ToolUse\Module;
 use BEAR\Resource\Module\JsonSchemaModule as ResourceJsonSchemaModule;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolCallObserverInterface;
 use BEAR\ToolUse\Dispatch\ToolRegistryInterface;
 use BEAR\ToolUse\Schema\JsonSchemaRepositoryInterface;
 use BEAR\ToolUse\Schema\SchemaConverterInterface;
@@ -37,6 +39,10 @@ final class ToolUseModuleTest extends TestCase
         $this->assertInstanceOf(
             DispatcherInterface::class,
             $injector->getInstance(DispatcherInterface::class),
+        );
+        $this->assertInstanceOf(
+            NullToolCallObserver::class,
+            $injector->getInstance(ToolCallObserverInterface::class),
         );
     }
 

--- a/tests/Runtime/AgentConfirmationTest.php
+++ b/tests/Runtime/AgentConfirmationTest.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Runtime;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeConfirmationHandler;
 use BEAR\ToolUse\Fake\FakeLlmClient;
@@ -32,7 +33,7 @@ final class AgentConfirmationTest extends TestCase
         $registry = new ToolRegistry();
         $registry->register('article_get', 'app://self/article', 'get');
         $registry->register('article_delete', 'app://self/article', 'delete');
-        $this->dispatcher = new Dispatcher($resource, $registry);
+        $this->dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
     }
 
     public function testConfirmationApproved(): void

--- a/tests/Runtime/AgentFactoryTest.php
+++ b/tests/Runtime/AgentFactoryTest.php
@@ -8,6 +8,7 @@ use BEAR\Resource\FactoryInterface;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeConfirmationHandler;
 use BEAR\ToolUse\Fake\FakeLlmClient;
@@ -35,7 +36,7 @@ final class AgentFactoryTest extends TestCase
         $registry = new ToolRegistry();
         $converter = new SchemaConverter(DocBlockFactory::createInstance());
         $collector = new ToolCollector($converter, $registry, $resourceFactory);
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $this->factory = new AgentFactory($this->llmClient, $dispatcher, $collector, $registry);
     }
@@ -108,7 +109,7 @@ final class AgentFactoryTest extends TestCase
         $registry   = new ToolRegistry();
         $converter  = new SchemaConverter(DocBlockFactory::createInstance());
         $collector  = new ToolCollector($converter, $registry, $resourceFactory);
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $factory = new AgentFactory($this->llmClient, $dispatcher, $collector, $registry, null, $streamingClient);
         $factory->addResources(['app://self/article']);
@@ -136,7 +137,7 @@ final class AgentFactoryTest extends TestCase
         $registry  = new ToolRegistry();
         $converter = new SchemaConverter(DocBlockFactory::createInstance());
         $collector = new ToolCollector($converter, $registry, $resourceFactory);
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $factory = new AgentFactory($this->llmClient, $dispatcher, $collector, $registry, $confirmationHandler);
         $factory->addResources(['app://self/article']);
@@ -163,7 +164,7 @@ final class AgentFactoryTest extends TestCase
         $registry   = new ToolRegistry();
         $converter  = new SchemaConverter(DocBlockFactory::createInstance());
         $collector  = new ToolCollector($converter, $registry, $resourceFactory);
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $factory = new AgentFactory(
             $this->llmClient,

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Runtime;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Fake\FakeLlmClient;
@@ -32,7 +33,7 @@ final class AgentTest extends TestCase
         $resource = $injector->getInstance(ResourceInterface::class);
         $registry = new ToolRegistry();
         $registry->register('article_get', 'article', 'get');
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $tools = [
             new Tool('article_get', 'Get an article', [
@@ -287,7 +288,7 @@ final class AgentTest extends TestCase
         $resource = $injector->getInstance(ResourceInterface::class);
         $registry = new ToolRegistry();
         $registry->register('error_get', 'app://self/error', 'get');
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $tools = [
             new Tool('error_get', 'Get error resource', [
@@ -336,7 +337,7 @@ final class AgentTest extends TestCase
         $registry = new ToolRegistry();
         $registry->register('error_get', 'app://self/error', 'get');
         $registry->register('article_get', 'app://self/article', 'get');
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $tools = [
             new Tool('error_get', 'Get error resource', [
@@ -394,7 +395,7 @@ final class AgentTest extends TestCase
         $resource = $injector->getInstance(ResourceInterface::class);
         $registry = new ToolRegistry();
         $registry->register('status_error_get', 'app://self/status-error', 'get');
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $tools = [
             new Tool('status_error_get', 'Get status error resource', [

--- a/tests/Runtime/StreamingAgentConfirmationTest.php
+++ b/tests/Runtime/StreamingAgentConfirmationTest.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Runtime;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Llm\StreamEvent;
@@ -36,7 +37,7 @@ final class StreamingAgentConfirmationTest extends TestCase
         $registry = new ToolRegistry();
         $registry->register('article_get', 'app://self/article', 'get');
         $registry->register('article_delete', 'app://self/article', 'delete');
-        $this->dispatcher = new Dispatcher($resource, $registry);
+        $this->dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
     }
 
     public function testConfirmationApproved(): void

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -7,6 +7,7 @@ namespace BEAR\ToolUse\Runtime;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Fake\FakeThrowingDispatcher;
@@ -39,7 +40,7 @@ final class StreamingAgentTest extends TestCase
         $resource = $injector->getInstance(ResourceInterface::class);
         $registry = new ToolRegistry();
         $registry->register('article_get', 'article', 'get');
-        $dispatcher = new Dispatcher($resource, $registry);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
 
         $tools = [
             new Tool('article_get', 'Get an article', [


### PR DESCRIPTION
## Motivation

Today, observing tool calls (audit logging to a DB, emitting metrics, measuring per-call latency, debugging traces) requires every consumer of this library to write their own `DispatcherInterface` decorator. That work gets reinvented in every project, often inconsistently, and there's no shared place for the library to evolve the observation contract.

This PR adds an official, minimal hook so observation is a first-class concern of the library.

## What it adds

- `ToolCallObserverInterface` — single method `observe(ToolCall, ToolResult, float $durationMs): void`
- `NullToolCallObserver` — default no-op implementation, bound by `ToolUseModule`
- `Dispatcher` now requires a `ToolCallObserverInterface` and invokes it **exactly once per dispatch**, after the result is determined, regardless of which path produced it:
  - Success
  - Resource status code >= 400
  - Exception thrown by the resource (or a filter)
  - Unknown tool (not registered)
- `durationMs` is measured with `hrtime(true)` for monotonic, sub-millisecond precision.

## Design choices

### Why a dedicated interface, not PSR-3 `LoggerInterface`?

- PSR-3 is for human-readable strings; `observe()` receives the actual `ToolCall` and `ToolResult` value objects. Consumers can serialize how they want (JSON, structured log, span attributes, DB row…) without first parsing log strings.
- Tool observation has its own semantics — name, input, success/error, post-filter content, elapsed time. A dedicated interface keeps the contract type-safe and tool-specific.
- Logging is one consumer of this hook, not the only one. Metrics emitters, audit log writers, and OpenTelemetry span recorders are equally valid implementations.

### Why is the `ToolResult` post-filter?

The observer receives the `ToolResult` that the **LLM will actually see** (after `ToolResultFilterInterface` has been applied on success paths). This is intentional — observability should reflect what was sent to the model, not the raw resource body, otherwise audit logs and metrics would diverge from the model's actual context.

### Why no thread/conversation/user-id parameter?

The interface is intentionally minimal. Application-level context (conversation IDs, user IDs, request IDs, OpenTelemetry trace context, …) is the responsibility of the consumer's stateful observer implementation. Baking such fields into the library's interface would either force every consumer to think about identifiers they don't need, or push the library into application-level concerns it shouldn't own.

### Cancelled tool calls are NOT observed

Confirmation denial (`ConfirmationHandlerInterface` returning `false`, or `StreamingAgent` `Generator::send(false)`) is handled at the `Agent` / `StreamingAgent` layer and returns `ToolResult::cancelled()` **without** calling `Dispatcher::dispatch()`. The observer is therefore not invoked for cancelled calls. If you need to record cancellations too, hook the agent layer separately.

### Observer exceptions propagate

Exceptions thrown from `observe()` propagate out of `Dispatcher::dispatch()`. This is intentional (errors should not pass silently and the framework is not the application boundary), but it does mean an observer I/O failure (e.g. a transient audit-DB outage) can break tool dispatch unless the observer wraps its own I/O in try/catch. Document this in your runbook for any I/O-touching observer implementation.

### Backwards compatibility

`ToolUseModule` binds `NullToolCallObserver` by default, so applications using the standard module configuration get the new constructor parameter for free — no code change required when upgrading.

Applications that compose their own modules without `ToolUseModule`, or that instantiate `Dispatcher` manually (e.g. in custom test setups), must add an observer explicitly. Given this is a DI-first library and the package is still pre-1.0, requiring the dependency keeps the design honest (no service-locator / `?? new …` fallback in the constructor).

## Test plan

- [x] `composer test` — 193 tests, 436 assertions, all pass
- [x] `composer cs` — clean
- [x] `composer phpmd` — clean
- [x] `composer sa` (Psalm level 1) — clean
- [x] `FakeToolCallObserver` records calls; tests assert `toolCall`/`result` identity and `durationMs > 0` on every dispatch path:
  - `testObserverInvokedOnSuccess`
  - `testObserverInvokedOnStatusError`
  - `testObserverInvokedOnException`
  - `testObserverInvokedOnUnknownTool`
- [x] `testObserverReceivesPostFilterResult` pins the post-filter contract by combining a filter + observer
- [x] `NullToolCallObserverTest::testObserveIsNoop` covers the default implementation
- [x] `ToolUseModuleTest::testBindings` verifies the default binding

## Docs

- README.md / README.ja.md: new "Observing Tool Calls" / "ツール呼び出しの観測" section, plus a row in the API interfaces table. Design Notes call out cancellation bypass and observer exception propagation.
- CHANGELOG.md: entry under `[0.1.0] - Unreleased > Added`

🤖 Generated with [Claude Code](https://claude.com/claude-code)