### PR TITLE
Promote ToolMapping and PendingToolCall from psalm-types to value objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ToolUseModule` for Ray.Di binding configuration
 
 ### Changed
-- Promoted internal `ToolMapping` and `PendingToolCall` from `@psalm-type` array shapes to dedicated `final readonly` value objects (`BEAR\ToolUse\Dispatch\ToolMapping`, `BEAR\ToolUse\Runtime\PendingToolCall`). Producers and consumers were the only ones each, both internal — no public-API impact unless you implemented `ToolRegistryInterface` yourself, in which case `get()` now returns `ToolMapping|null` instead of an array shape.
+- **BREAKING (interface implementers only)**: `ToolRegistryInterface::get()` now returns `BEAR\ToolUse\Dispatch\ToolMapping|null` instead of an `array{resourceUri: string, method: string, filter?: class-string}|null` shape. Direct `ToolRegistry` users are unaffected (`register()` signature is unchanged). Internal `PendingToolCall` (used by the streaming pipeline) was likewise promoted from `@psalm-type` to `BEAR\ToolUse\Runtime\PendingToolCall` — `final readonly class`. Both promotions remove static-only Psalm enforcement in favor of runtime type safety; consumer code switches from `$mapping['filter'] ?? null` style to property access.
 - **BREAKING**: `AlpsSemanticDictionary` now takes a profile file path (`string`) instead of a `Koriym\AppStateDiagram\Profile` instance.
 
   ```php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ToolUseModule` for Ray.Di binding configuration
 
 ### Changed
+- Promoted internal `ToolMapping` and `PendingToolCall` from `@psalm-type` array shapes to dedicated `final readonly` value objects (`BEAR\ToolUse\Dispatch\ToolMapping`, `BEAR\ToolUse\Runtime\PendingToolCall`). Producers and consumers were the only ones each, both internal — no public-API impact unless you implemented `ToolRegistryInterface` yourself, in which case `get()` now returns `ToolMapping|null` instead of an array shape.
 - **BREAKING**: `AlpsSemanticDictionary` now takes a profile file path (`string`) instead of a `Koriym\AppStateDiagram\Profile` instance.
 
   ```php

--- a/src/Dispatch/Dispatcher.php
+++ b/src/Dispatch/Dispatcher.php
@@ -43,8 +43,8 @@ final readonly class Dispatcher implements DispatcherInterface
 
         try {
             $ro = $this->invokeResource(
-                $mapping['resourceUri'],
-                $mapping['method'],
+                $mapping->resourceUri,
+                $mapping->method,
                 $toolCall->input,
             );
 
@@ -59,9 +59,8 @@ final readonly class Dispatcher implements DispatcherInterface
 
             /** @var mixed $body */
             $body = $ro->body;
-            if (isset($mapping['filter'])) {
-                /** @var class-string<ToolResultFilterInterface> $filterClass */
-                $filterClass = $mapping['filter'];
+            if ($mapping->filter !== null) {
+                $filterClass = $mapping->filter;
                 /** @var mixed $body */
                 $body = (new $filterClass())($body);
             }

--- a/src/Dispatch/ToolMapping.php
+++ b/src/Dispatch/ToolMapping.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Dispatch;
+
+/**
+ * Resolved mapping from tool name to its backing resource invocation
+ */
+final readonly class ToolMapping
+{
+    /** @param class-string<ToolResultFilterInterface>|null $filter */
+    public function __construct(
+        public string $resourceUri,
+        public string $method,
+        public string|null $filter = null,
+    ) {
+    }
+}

--- a/src/Dispatch/ToolRegistry.php
+++ b/src/Dispatch/ToolRegistry.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Dispatch;
 
-use BEAR\ToolUse\Types;
 use Override;
 
-use function array_key_exists;
 use function array_keys;
 
 /**
  * Registry for tool name to resource mapping
- *
- * @psalm-import-type ToolMapping from Types
  */
 final class ToolRegistry implements ToolRegistryInterface
 {
@@ -31,37 +27,19 @@ final class ToolRegistry implements ToolRegistryInterface
     #[Override]
     public function register(string $toolName, string $resourceUri, string $method, string|null $filter = null): void
     {
-        $mapping = [
-            'resourceUri' => $resourceUri,
-            'method' => $method,
-        ];
-
-        if ($filter !== null) {
-            $mapping['filter'] = $filter;
-        }
-
-        $this->mappings[$toolName] = $mapping;
+        $this->mappings[$toolName] = new ToolMapping($resourceUri, $method, $filter);
     }
 
-    /**
-     * Get mapping for a tool name
-     *
-     * @return ToolMapping|null
-     */
     #[Override]
-    public function get(string $toolName): array|null
+    public function get(string $toolName): ToolMapping|null
     {
-        if (! array_key_exists($toolName, $this->mappings)) {
-            return null;
-        }
-
-        return $this->mappings[$toolName];
+        return $this->mappings[$toolName] ?? null;
     }
 
     #[Override]
     public function has(string $toolName): bool
     {
-        return array_key_exists($toolName, $this->mappings);
+        return isset($this->mappings[$toolName]);
     }
 
     /** @return list<string> */

--- a/src/Dispatch/ToolRegistryInterface.php
+++ b/src/Dispatch/ToolRegistryInterface.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Dispatch;
 
-use BEAR\ToolUse\Types;
-
 /**
  * Registry for tool name to resource mapping
- *
- * @psalm-import-type ToolMapping from Types
  */
 interface ToolRegistryInterface
 {
@@ -25,10 +21,8 @@ interface ToolRegistryInterface
 
     /**
      * Get mapping for a tool name
-     *
-     * @return ToolMapping|null
      */
-    public function get(string $toolName): array|null;
+    public function get(string $toolName): ToolMapping|null;
 
     /**
      * Check if a tool is registered

--- a/src/Runtime/PendingToolCall.php
+++ b/src/Runtime/PendingToolCall.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+/**
+ * Tool call accumulated during streaming, before its JSON input is decoded
+ */
+final readonly class PendingToolCall
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $inputJson,
+    ) {
+    }
+}

--- a/src/Runtime/StreamContentAccumulator.php
+++ b/src/Runtime/StreamContentAccumulator.php
@@ -13,7 +13,6 @@ use function json_decode;
 /**
  * Accumulates stream events into content blocks and iteration state
  *
- * @psalm-import-type PendingToolCall from Types
  * @psalm-import-type ContentBlock from Types
  */
 final class StreamContentAccumulator
@@ -119,11 +118,11 @@ final class StreamContentAccumulator
     private function finalizeContentBlock(): void
     {
         if ($this->currentToolName !== '') {
-            $this->pendingToolCalls[] = [
-                'id' => $this->currentToolId,
-                'name' => $this->currentToolName,
-                'inputJson' => $this->currentToolInputJson,
-            ];
+            $this->pendingToolCalls[] = new PendingToolCall(
+                $this->currentToolId,
+                $this->currentToolName,
+                $this->currentToolInputJson,
+            );
             /** @var array<string, mixed> $input */
             $input = (array) json_decode($this->currentToolInputJson, true);
             $this->contentBlocks[] = [

--- a/src/Runtime/StreamIterationState.php
+++ b/src/Runtime/StreamIterationState.php
@@ -9,7 +9,6 @@ use BEAR\ToolUse\Types;
 /**
  * State accumulated during a single streaming iteration
  *
- * @psalm-import-type PendingToolCall from Types
  * @psalm-import-type ContentBlock from Types
  */
 final readonly class StreamIterationState

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -10,7 +10,6 @@ use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Llm\StreamingLlmClientInterface;
 use BEAR\ToolUse\Schema\Tool;
-use BEAR\ToolUse\Types;
 use Generator;
 use Override;
 use Throwable;
@@ -27,8 +26,6 @@ use function json_decode;
  * For confirmable tools, yields AgentEvent::CONFIRMATION_REQUIRED and
  * receives approval via Generator::send(bool). If send() is not called
  * (e.g. iterator_to_array), the tool is denied by default (safe default).
- *
- * @psalm-import-type PendingToolCall from Types
  */
 final class StreamingAgent implements StreamingAgentInterface
 {
@@ -159,10 +156,10 @@ final class StreamingAgent implements StreamingAgentInterface
         $toolResults = [];
         foreach ($pendingToolCalls as $pending) {
             /** @var array<string, mixed> $input */
-            $input = (array) json_decode($pending['inputJson'], true);
+            $input = (array) json_decode($pending->inputJson, true);
             $toolCall = new ToolCall(
-                id: $pending['id'],
-                name: $pending['name'],
+                id: $pending->id,
+                name: $pending->name,
                 input: $input,
             );
 
@@ -179,7 +176,7 @@ final class StreamingAgent implements StreamingAgentInterface
                     $result = ToolResult::cancelled($toolCall->id);
                     $toolResults[] = $result;
 
-                    yield AgentEvent::toolResult($pending['name']);
+                    yield AgentEvent::toolResult($pending->name);
 
                     continue;
                 }
@@ -193,7 +190,7 @@ final class StreamingAgent implements StreamingAgentInterface
 
             $toolResults[] = $result;
 
-            yield AgentEvent::toolResult($pending['name']);
+            yield AgentEvent::toolResult($pending->name);
         }
 
         return $toolResults;

--- a/src/Types.php
+++ b/src/Types.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse;
 
-use BEAR\ToolUse\Dispatch\ToolResultFilterInterface;
 use BEAR\ToolUse\Llm\StreamEvent;
 use Generator;
 
@@ -12,8 +11,6 @@ use Generator;
  * Domain types for BEAR.ToolUse
  *
  * @psalm-type InputSchema = array{type: string, properties: array<string, mixed>, required?: list<string>}
- * @psalm-type ToolMapping = array{resourceUri: string, method: string, filter?: class-string<ToolResultFilterInterface>}
- * @psalm-type PendingToolCall = array{id: string, name: string, inputJson: string}
  * @psalm-type ContentBlock = array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}
  * @psalm-type StreamGenerator = Generator<int, StreamEvent, mixed, void>
  */

--- a/tests/Dispatch/ToolRegistryTest.php
+++ b/tests/Dispatch/ToolRegistryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ToolRegistry::class)]
+#[CoversClass(ToolMapping::class)]
 final class ToolRegistryTest extends TestCase
 {
     private ToolRegistry $registry;
@@ -25,8 +26,8 @@ final class ToolRegistryTest extends TestCase
         $mapping = $this->registry->get('article_get');
 
         $this->assertNotNull($mapping);
-        $this->assertSame('article', $mapping['resourceUri']);
-        $this->assertSame('get', $mapping['method']);
+        $this->assertSame('article', $mapping->resourceUri);
+        $this->assertSame('get', $mapping->method);
     }
 
     public function testHas(): void
@@ -63,18 +64,18 @@ final class ToolRegistryTest extends TestCase
         $mapping = $this->registry->get('search_get');
 
         $this->assertNotNull($mapping);
-        $this->assertSame('search', $mapping['resourceUri']);
-        $this->assertSame('get', $mapping['method']);
-        $this->assertSame(FakeSummaryFilter::class, $mapping['filter']);
+        $this->assertSame('search', $mapping->resourceUri);
+        $this->assertSame('get', $mapping->method);
+        $this->assertSame(FakeSummaryFilter::class, $mapping->filter);
     }
 
-    public function testRegisterWithoutFilterOmitsKey(): void
+    public function testRegisterWithoutFilterDefaultsToNull(): void
     {
         $this->registry->register('article_get', 'article', 'get');
 
         $mapping = $this->registry->get('article_get');
 
         $this->assertNotNull($mapping);
-        $this->assertArrayNotHasKey('filter', $mapping);
+        $this->assertNull($mapping->filter);
     }
 }

--- a/tests/Runtime/PendingToolCallTest.php
+++ b/tests/Runtime/PendingToolCallTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PendingToolCall::class)]
+final class PendingToolCallTest extends TestCase
+{
+    public function testExposesConstructorArgumentsAsProperties(): void
+    {
+        $pending = new PendingToolCall('call_1', 'article_get', '{"id":1}');
+
+        $this->assertSame('call_1', $pending->id);
+        $this->assertSame('article_get', $pending->name);
+        $this->assertSame('{"id":1}', $pending->inputJson);
+    }
+}

--- a/tests/Schema/ToolCollectorTest.php
+++ b/tests/Schema/ToolCollectorTest.php
@@ -64,8 +64,8 @@ final class ToolCollectorTest extends TestCase
 
         $mapping = $this->registry->get('article_get');
         $this->assertNotNull($mapping);
-        $this->assertSame('app://self/article', $mapping['resourceUri']);
-        $this->assertSame('get', $mapping['method']);
+        $this->assertSame('app://self/article', $mapping->resourceUri);
+        $this->assertSame('get', $mapping->method);
     }
 
     public function testCustomToolNameFallsBackToGet(): void
@@ -74,7 +74,7 @@ final class ToolCollectorTest extends TestCase
 
         $mapping = $this->registry->get('my_custom_tool');
         $this->assertNotNull($mapping);
-        $this->assertSame('get', $mapping['method']);
+        $this->assertSame('get', $mapping->method);
     }
 
     public function testPathWithHyphensConverted(): void
@@ -85,7 +85,7 @@ final class ToolCollectorTest extends TestCase
 
         $mapping = $this->registry->get('my_article_get');
         $this->assertNotNull($mapping);
-        $this->assertSame('app://self/my-article', $mapping['resourceUri']);
+        $this->assertSame('app://self/my-article', $mapping->resourceUri);
     }
 
     public function testFullUriStoredInRegistry(): void
@@ -94,7 +94,7 @@ final class ToolCollectorTest extends TestCase
 
         $mapping = $this->registry->get('article_get');
         $this->assertNotNull($mapping);
-        $this->assertSame('app://self/article', $mapping['resourceUri']);
+        $this->assertSame('app://self/article', $mapping->resourceUri);
     }
 
     public function testCustomToolNameWithMethodSuffix(): void
@@ -103,7 +103,7 @@ final class ToolCollectorTest extends TestCase
 
         $mapping = $this->registry->get('custom_action_post');
         $this->assertNotNull($mapping);
-        $this->assertSame('post', $mapping['method']);
+        $this->assertSame('post', $mapping->method);
     }
 
     public function testDifferentSchemes(): void
@@ -113,7 +113,7 @@ final class ToolCollectorTest extends TestCase
         $this->assertCount(1, $tools);
         $mapping = $this->registry->get('article_get');
         $this->assertNotNull($mapping);
-        $this->assertSame('page://self/article', $mapping['resourceUri']);
+        $this->assertSame('page://self/article', $mapping->resourceUri);
     }
 
     public function testFilterPropagatedToRegistry(): void
@@ -122,6 +122,6 @@ final class ToolCollectorTest extends TestCase
 
         $mapping = $this->registry->get('filtered_get');
         $this->assertNotNull($mapping);
-        $this->assertSame(FakeSummaryFilter::class, $mapping['filter']);
+        $this->assertSame(FakeSummaryFilter::class, $mapping->filter);
     }
 }


### PR DESCRIPTION
## Motivation

`Types.php` declares 5 `@psalm-type` aliases. Two of them — `ToolMapping` and `PendingToolCall` — are the **only purely-internal types** with a single producer / single consumer that never cross any external boundary (no JSON serialization, no LLM API contact). Every other major data structure in the project (`ToolCall`, `ToolResult`, `Tool`, `Message`, `LlmResponse`, `AgentEvent`, …) is a `final readonly class`. These two array shapes are the odd ones out.

This PR converts them to value objects, removing static-only enforcement in favor of runtime type safety, and shrinking consumer code by removing array-key dances.

## What changes

### `ToolMapping` (Dispatch/)

- **Producer**: `ToolRegistry::register()`
- **Consumer**: `Dispatcher::resolve()`
- Was: `array{resourceUri: string, method: string, filter?: class-string<ToolResultFilterInterface>}`
- Now: `final readonly class ToolMapping { public string $resourceUri, public string $method, public ?string $filter }`

The cleanup ripples nicely through `Dispatcher::resolve()`:

```php
// Before
if (isset($mapping['filter'])) {
    /** @var class-string<ToolResultFilterInterface> $filterClass */
    $filterClass = $mapping['filter'];
    $body = (new $filterClass())($body);
}

// After
if ($mapping->filter !== null) {
    $filterClass = $mapping->filter;
    $body = (new $filterClass())($body);
}
```

The `@var` PHPDoc annotation goes away because `class-string<ToolResultFilterInterface>` is now declared on the property itself.

### `PendingToolCall` (Runtime/)

- **Producer**: `StreamContentAccumulator::finalizeContentBlock()`
- **Consumer**: `StreamingAgent::dispatchPendingToolCalls()`
- Was: `array{id: string, name: string, inputJson: string}`
- Now: `final readonly class PendingToolCall { public string $id, public string $name, public string $inputJson }`

Conceptually it's "a `ToolCall` whose input is still a JSON string". Promoting it to a class makes that intent explicit and consistent with the surrounding pipeline (which already uses class objects everywhere else).

## Why the other three psalm-types stay as arrays

| Type | Why kept as array shape |
|------|------------------------|
| `InputSchema` | Thin wrapper over the JSON Schema spec. `properties` is `array<string, mixed>` of arbitrary JSON Schema fragments — class-ifying would force re-modeling the spec, with `properties` still falling back to `array<string, mixed>`. Also serialized verbatim into `Tool::jsonSerialize()`. |
| `ContentBlock` | LLM API **discriminated union** (`type` discriminator with variant-specific fields). A single class with all-nullable properties would lose the variant-specific type guarantees. The "right" refactor is a class hierarchy (`TextBlock` / `ToolUseBlock` / `ToolResultBlock`), which is a separate, larger task. |
| `StreamGenerator` | Pure `Generator<int, StreamEvent, mixed, void>` type alias — not a struct. |

## Public-API impact

**BREAKING (interface implementers only)**: `ToolRegistryInterface::get()` now returns `ToolMapping|null` instead of an array shape. Anyone implementing `ToolRegistryInterface` themselves must update their return type. Direct `ToolRegistry` users are unaffected — `register()` takes the same positional arguments. `Dispatcher` is bound by `ToolUseModule`, so DI-driven users see no change. Pre-1.0 release; documented in CHANGELOG.

## Test plan

- [x] `composer test` — 188 tests, 411 assertions, all pass
- [x] `composer cs` — clean
- [x] `composer phpmd` — clean
- [x] `composer sa` (Psalm level 1) — clean
- [x] Existing `ToolRegistryTest` updated to use property access; `#[CoversClass(ToolMapping::class)]` added
- [x] Existing `ToolCollectorTest` updated to use property access
- [x] Streaming pipeline tests (`StreamingAgentTest`, etc.) cover the `PendingToolCall` producer/consumer end-to-end
- [x] New `PendingToolCallTest` adds explicit `#[CoversClass(PendingToolCall::class)]` for codecov attribution

## Stats

```
13 files changed, 94 insertions(+), 71 deletions(-)
```

Two new value-object class files (`ToolMapping.php`, `PendingToolCall.php`) plus one new test file (`PendingToolCallTest.php`). The remaining diff is mostly consumer code shrinking — `isset` / array-access ceremony goes away in `Dispatcher::resolve()` and the streaming pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)