### PR TITLE
Add P0 agent extension APIs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -134,7 +134,95 @@ if ($response->completed) {
 }
 ```
 
-### 5. 会話履歴
+### 5. 呼び出し単位のツール制限
+
+`AgentOptions` を使うと、1回の `run()` で利用できるツールを制限できます。収集済みの Resource registry は変更せず、その呼び出しで LLM に渡す tool list だけを絞ります。
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+
+$response = $agent->run(
+    '記事を検索してください。変更はしないでください。',
+    AgentOptions::withTools(['article_get', 'search_get']),
+);
+```
+
+存在しない tool 名を指定した場合は、LLM 呼び出し前に例外になります。typo や policy 設定ミスを早期に検出できます。
+
+Streaming Agent でも同じ option を使えます。
+
+```php
+foreach ($agent->runStream('記事を検索して', AgentOptions::withTools(['search_get'])) as $event) {
+    // ...
+}
+```
+
+### 6. Input/Output Processor
+
+Processor を使うと、Agent runtime を肥大化させずに各 LLM 呼び出しを拡張できます。Input Processor は LLM 呼び出し前に system prompt、messages、tools を加工できます。Output Processor は LLM 呼び出し後の response を検査・正規化できます。tool result 後の再問い合わせを含め、各 iteration で毎回適用されます。
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\Message;
+
+final class MemoryProcessor implements InputProcessorInterface
+{
+    public function process(LlmRequest $request): LlmRequest
+    {
+        return $request->withMessages([
+            ...$request->messages,
+            Message::user('既知の文脈: ユーザーは簡潔な回答を好む。'),
+        ]);
+    }
+}
+
+$response = $agent->run(
+    'この記事を要約して',
+    AgentOptions::withProcessors(inputProcessors: [new MemoryProcessor()]),
+);
+```
+
+`OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。
+
+### 7. Agent-as-Tool / Named Subagent
+
+専門エージェントを `AgentPool` に登録すると、`ask_{name}` という tool として公開できます。Subagent の会話履歴は呼び出しごとに隔離されます。
+
+```php
+use BEAR\ToolUse\Runtime\AgentDelegator;
+use BEAR\ToolUse\Runtime\AgentFactory;
+use BEAR\ToolUse\Runtime\AgentPool;
+use BEAR\ToolUse\Runtime\AgentProfile;
+
+$pool = new AgentPool($llmClient, $resourceDispatcher, $collector);
+$pool->register(new AgentProfile(
+    name: 'critic',
+    description: '設計上のリスクをレビューする',
+    systemPrompt: 'You are a critical reviewer.',
+    resources: ['app://self/article'],
+));
+
+$delegator = new AgentDelegator($pool, $resourceDispatcher);
+$factory = new AgentFactory($llmClient, $delegator, $collector, $registry);
+
+$agent = $factory
+    ->addResources(['app://self/article'])
+    ->addSubagents($pool)
+    ->create('あなたは調整役のエージェントです。');
+
+// LLM が ask_critic を呼ぶと、AgentDelegator が critic agent を実行し、
+// 結果を通常の tool_result として LLM に返します。
+```
+
+Subagent は直接呼び出すこともできます。
+
+```php
+$response = $delegator->ask('critic', 'この設計のリスクは？', ['articleId' => 1]);
+```
+
+### 8. 会話履歴
 
 エージェントは複数の `run()` 呼び出しにわたって会話履歴を保持します。
 
@@ -156,7 +244,7 @@ $response = $agent->run('このユーザーについてもっと教えて');
 $agent->reset();
 ```
 
-### 6. ストリーミングエージェント
+### 9. ストリーミングエージェント
 
 リアルタイム出力（SSE、WebSocket）には、ストリーミングエージェントを使用します。LLMの出力に応じてイベントをyieldします。
 
@@ -569,6 +657,8 @@ Dispatcherが検出するエラー:
 | `AgentInterface` | エージェントランタイム |
 | `StreamingAgentInterface` | ストリーミングエージェントランタイム |
 | `ToolResultFilterInterface` | LLM送信前のレスポンスフィルタ |
+| `InputProcessorInterface` | LLM 呼び出し前に request を処理 |
+| `OutputProcessorInterface` | LLM 呼び出し後に response または stream event を処理 |
 | `ConfirmationHandlerInterface` | 破壊的ツールのユーザー確認 |
 | `ToolCallObserverInterface` | ディスパッチごとに 1 回呼ばれるフック（監査・メトリクス・レイテンシ計測） |
 
@@ -579,6 +669,11 @@ Dispatcherが検出するエラー:
 | `Agent` | LLMとの会話ループを管理 |
 | `StreamingAgent` | `AgentEvent`をyieldするストリーミング会話ループ |
 | `AgentFactory` | エージェントのビルダー（同期・ストリーミング） |
+| `AgentOptions` | ツール制限などの呼び出し単位オプション |
+| `LlmRequest` | Input Processor に渡される LLM request |
+| `AgentProfile` | Named Subagent の設定 |
+| `AgentPool` | Named Subagent の登録・作成 |
+| `AgentDelegator` | `ask_*` tool call を Subagent に委譲 |
 | `AgentResponse` | エージェント実行結果（同期） |
 | `AgentEvent` | ストリーミングイベント（`JsonSerializable`） |
 | `StreamEvent` | 低レベルLLMストリームイベント |

--- a/README.ja.md
+++ b/README.ja.md
@@ -186,6 +186,20 @@ $response = $agent->run(
 
 `OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。
 
+#### フックの使い分け
+
+拡張フックは意図的に直交していますが、同じような処理を複数の場所で実装できる場合があります。影響させたいレイヤに合うフックを選んでください。
+
+| やりたいこと | 使うもの | 理由 |
+|---|---|---|
+| LLM 呼び出し前に記憶・ポリシー・文脈を追加する | `InputProcessorInterface` | 各 LLM 呼び出し前に実行され、system prompt、messages、tools を変更できるため |
+| LLM 応答全体を正規化・検閲する | `OutputProcessorInterface` | LLM 呼び出し後の response または stream event 全体を見られるため |
+| tool 実行ログ・監査ログを記録する | `ToolCallObserverInterface` | 結果を変更せず、すべての dispatch 経路を観測できるため |
+| tool のレイテンシや成功／失敗メトリクスを送る | `ToolCallObserverInterface` | 各 dispatch の `durationMs` を受け取れるため |
+| 特定 tool の成功レスポンスをマスク・削減・整形する | `#[Tool(filter: ...)]` | tool 固有に、LLM へ返す結果そのものを変換できるため |
+
+目安として、LLM request/response 全体の変換には Processor、変換しないテレメトリには Observer、tool 固有の結果変換には Filter を使います。
+
 ### 7. Agent-as-Tool / Named Subagent
 
 専門エージェントを `AgentPool` に登録すると、`ask_{name}` という tool として公開できます。Subagent の会話履歴は呼び出しごとに隔離されます。
@@ -215,6 +229,8 @@ $agent = $factory
 // LLM が ask_critic を呼ぶと、AgentDelegator が critic agent を実行し、
 // 結果を通常の tool_result として LLM に返します。
 ```
+
+`addSubagents($pool)` は、LLM に送る tool list に `ask_*` の tool 定義を追加するだけです。実行時にそれらの tool call を処理するには、その Agent の dispatcher として `AgentDelegator` を使う必要があります。同じ Agent が通常の resource tool も公開する場合は、通常の `Dispatcher` を fallback として渡してください。DI モジュールで `DispatcherInterface` を直接 `Dispatcher` に bind している場合、subagent を公開する Agent では `AgentDelegator` を使うように構成してください。
 
 Subagent は直接呼び出すこともできます。
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,95 @@ if ($response->completed) {
 }
 ```
 
-### 5. Conversation History
+### 5. Per-call Tool Filtering
+
+Use `AgentOptions` to limit the tools available for a single run. This does not change the collected resource registry; it only narrows the tools sent to the LLM for that invocation.
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+
+$response = $agent->run(
+    'Please search articles, but do not modify anything.',
+    AgentOptions::withTools(['article_get', 'search_get']),
+);
+```
+
+Unknown tool names fail fast, so typos or policy mistakes are detected before the LLM call.
+
+The same option is available for streaming:
+
+```php
+foreach ($agent->runStream('Search articles', AgentOptions::withTools(['search_get'])) as $event) {
+    // ...
+}
+```
+
+### 6. Input/Output Processors
+
+Processors let you extend each LLM call without making the agent runtime larger. Input processors can rewrite the system prompt, messages, or tools before the LLM call. Output processors can inspect or rewrite the LLM response after the call. They run on every iteration, including calls after tool results.
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\Message;
+
+final class MemoryProcessor implements InputProcessorInterface
+{
+    public function process(LlmRequest $request): LlmRequest
+    {
+        return $request->withMessages([
+            ...$request->messages,
+            Message::user('Known context: the user prefers concise answers.'),
+        ]);
+    }
+}
+
+$response = $agent->run(
+    'Summarize this article',
+    AgentOptions::withProcessors(inputProcessors: [new MemoryProcessor()]),
+);
+```
+
+`OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents.
+
+### 7. Agent-as-Tool / Named Subagents
+
+Register specialist agents in an `AgentPool`, then expose them as tools named `ask_{name}`. Subagent conversation history is isolated per call.
+
+```php
+use BEAR\ToolUse\Runtime\AgentDelegator;
+use BEAR\ToolUse\Runtime\AgentFactory;
+use BEAR\ToolUse\Runtime\AgentPool;
+use BEAR\ToolUse\Runtime\AgentProfile;
+
+$pool = new AgentPool($llmClient, $resourceDispatcher, $collector);
+$pool->register(new AgentProfile(
+    name: 'critic',
+    description: 'Review design risks',
+    systemPrompt: 'You are a critical reviewer.',
+    resources: ['app://self/article'],
+));
+
+$delegator = new AgentDelegator($pool, $resourceDispatcher);
+$factory = new AgentFactory($llmClient, $delegator, $collector, $registry);
+
+$agent = $factory
+    ->addResources(['app://self/article'])
+    ->addSubagents($pool)
+    ->create('You are a coordinator.');
+
+// When the LLM calls ask_critic, AgentDelegator runs the critic agent and
+// feeds the result back as a normal tool_result.
+```
+
+You can also call a subagent directly:
+
+```php
+$response = $delegator->ask('critic', 'What are the risks?', ['articleId' => 1]);
+```
+
+### 8. Conversation History
 
 The agent maintains conversation history across multiple `run()` calls.
 
@@ -156,7 +244,7 @@ $response = $agent->run('Tell me more about this user');
 $agent->reset();
 ```
 
-### 6. Streaming Agent
+### 9. Streaming Agent
 
 For real-time output (SSE, WebSocket), use the streaming agent. It yields events as the LLM generates output.
 
@@ -569,6 +657,8 @@ Errors detected by the Dispatcher:
 | `AgentInterface` | Agent runtime |
 | `StreamingAgentInterface` | Streaming agent runtime |
 | `ToolResultFilterInterface` | Response filter before sending to LLM |
+| `InputProcessorInterface` | Processes each LLM request before the call |
+| `OutputProcessorInterface` | Processes each LLM response or stream event after the call |
 | `ConfirmationHandlerInterface` | User confirmation for destructive tools |
 | `ToolCallObserverInterface` | Hook invoked once per tool dispatch (audit, metrics, latency) |
 
@@ -579,6 +669,11 @@ Errors detected by the Dispatcher:
 | `Agent` | Manages conversation loop with LLM |
 | `StreamingAgent` | Streaming conversation loop yielding `AgentEvent` |
 | `AgentFactory` | Builder for agents (sync and streaming) |
+| `AgentOptions` | Per-run options such as tool filtering |
+| `LlmRequest` | LLM request passed to input processors |
+| `AgentProfile` | Configuration for a named subagent |
+| `AgentPool` | Registry and factory for named subagents |
+| `AgentDelegator` | Dispatches `ask_*` tool calls to subagents |
 | `AgentResponse` | Agent execution result (sync) |
 | `AgentEvent` | Streaming event (`JsonSerializable`) |
 | `StreamEvent` | Low-level LLM stream event |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ $response = $agent->run(
 
 `OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents.
 
+#### Choosing the Right Extension Hook
+
+The extension hooks are intentionally orthogonal, but some tasks can be implemented in more than one place. Prefer the hook that matches the layer you want to affect:
+
+| Task | Use | Why |
+|---|---|---|
+| Add memory, policy, or request context before the LLM call | `InputProcessorInterface` | It runs before every LLM call and can rewrite the system prompt, messages, or tools. |
+| Normalize or moderate the full LLM response | `OutputProcessorInterface` | It sees each LLM response or stream event after the call. |
+| Record tool execution logs or audit trails | `ToolCallObserverInterface` | It observes every dispatch path without changing the result. |
+| Emit tool latency or success/error metrics | `ToolCallObserverInterface` | It receives `durationMs` for each dispatch. |
+| Redact, trim, or reshape one tool's successful response | `#[Tool(filter: ...)]` | It is tool-specific and changes exactly what is sent back to the LLM. |
+
+As a rule of thumb: use processors for LLM request/response transformation, observers for non-mutating telemetry, and filters for tool-specific result transformation.
+
 ### 7. Agent-as-Tool / Named Subagents
 
 Register specialist agents in an `AgentPool`, then expose them as tools named `ask_{name}`. Subagent conversation history is isolated per call.
@@ -215,6 +229,8 @@ $agent = $factory
 // When the LLM calls ask_critic, AgentDelegator runs the critic agent and
 // feeds the result back as a normal tool_result.
 ```
+
+`addSubagents($pool)` only adds the `ask_*` tool definitions to the list sent to the LLM. To execute those tool calls, the agent must use an `AgentDelegator` as its dispatcher. Pass the normal resource `Dispatcher` as the fallback when the same agent also exposes resource tools. If your DI module binds `DispatcherInterface` directly to `Dispatcher`, configure the agent that exposes subagents to use `AgentDelegator` instead.
 
 You can also call a subagent directly:
 

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -24,7 +24,6 @@ final class Agent implements AgentInterface
 {
     /** @var list<Message> */
     public array $messages = [];
-    private readonly ToolList $toolList;
 
     /** @param list<Tool> $tools */
     public function __construct(
@@ -35,7 +34,6 @@ final class Agent implements AgentInterface
         private readonly int $maxIterations = 10,
         private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
     ) {
-        $this->toolList = new ToolList($this->tools);
     }
 
     /**
@@ -44,16 +42,22 @@ final class Agent implements AgentInterface
      * Note: Messages accumulate across calls. Use reset() to clear history.
      */
     #[Override]
-    public function run(string $userMessage): AgentResponse
+    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse
     {
+        $runTools = $this->resolveTools($options);
+        $enforceToolList = $options?->enforcesToolList() ?? false;
+
         $this->messages[] = Message::user($userMessage);
 
         for ($i = 0; $i < $this->maxIterations; $i++) {
+            $request = $this->createRequest($runTools, $options);
             $response = $this->client->chat(
-                system: $this->systemPrompt,
-                messages: $this->messages,
-                tools: $this->tools,
+                system: $request->systemPrompt,
+                messages: $request->messages,
+                tools: $request->tools,
             );
+            $response = $options?->processResponse($response, $request) ?? $response;
+            $requestToolList = new ToolList($request->tools);
 
             switch ($response->stopReason) {
                 case 'end_turn':
@@ -61,7 +65,7 @@ final class Agent implements AgentInterface
 
                 case 'tool_use':
                     $this->messages[] = Message::assistant($response->content);
-                    $toolResults      = $this->processToolCalls($response);
+                    $toolResults      = $this->processToolCalls($response, $requestToolList, $enforceToolList);
                     $this->messages[] = Message::toolResults($toolResults);
                     break;
 
@@ -82,6 +86,20 @@ final class Agent implements AgentInterface
         return AgentResponse::maxIterationsReached($this->messages);
     }
 
+    /** @return list<Tool> */
+    private function resolveTools(AgentOptions|null $options): array
+    {
+        return $options?->filterTools($this->tools) ?? $this->tools;
+    }
+
+    /** @param list<Tool> $tools */
+    private function createRequest(array $tools, AgentOptions|null $options): LlmRequest
+    {
+        $request = new LlmRequest($this->systemPrompt, $this->messages, $tools);
+
+        return $options?->processRequest($request) ?? $request;
+    }
+
     /**
      * Clear conversation history to start a new conversation
      */
@@ -92,11 +110,17 @@ final class Agent implements AgentInterface
     }
 
     /** @return list<ToolResult> */
-    private function processToolCalls(LlmResponse $response): array
+    private function processToolCalls(LlmResponse $response, ToolList $toolList, bool $enforceToolList): array
     {
         $toolResults = [];
         foreach ($response->toolCalls as $toolCall) {
-            if ($this->isCancelled($toolCall, $response->getText())) {
+            if ($enforceToolList && ! $toolList->has($toolCall->name)) {
+                $toolResults[] = ToolResult::error($toolCall->id, 'Tool is not enabled: ' . $toolCall->name);
+
+                continue;
+            }
+
+            if ($this->isCancelled($toolCall, $response->getText(), $toolList)) {
                 $toolResults[] = ToolResult::cancelled($toolCall->id);
 
                 continue;
@@ -108,9 +132,9 @@ final class Agent implements AgentInterface
         return $toolResults;
     }
 
-    private function isCancelled(ToolCall $toolCall, string $llmText): bool
+    private function isCancelled(ToolCall $toolCall, string $llmText, ToolList $toolList): bool
     {
-        if (! $this->requiresConfirmation($toolCall)) {
+        if (! $this->requiresConfirmation($toolCall, $toolList)) {
             return false;
         }
 
@@ -120,9 +144,9 @@ final class Agent implements AgentInterface
         return ! $confirmationHandler->confirm($toolCall, $llmText);
     }
 
-    private function requiresConfirmation(ToolCall $toolCall): bool
+    private function requiresConfirmation(ToolCall $toolCall, ToolList $toolList): bool
     {
         return $this->confirmationHandler !== null
-            && $this->toolList->isConfirmable($toolCall->name);
+            && $toolList->isConfirmable($toolCall->name);
     }
 }

--- a/src/Runtime/AgentDelegator.php
+++ b/src/Runtime/AgentDelegator.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use Override;
+
+use function array_keys;
+use function is_array;
+use function is_string;
+use function json_encode;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Delegates ask_* tool calls to named subagents
+ */
+final readonly class AgentDelegator implements DispatcherInterface
+{
+    private const TOOL_PREFIX = 'ask_';
+
+    public function __construct(
+        private AgentPool $pool,
+        private DispatcherInterface|null $fallback = null,
+    ) {
+    }
+
+    /**
+     * Ask a named subagent directly.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function ask(string $name, string $message, array $context = []): AgentResponse
+    {
+        $profile = $this->pool->get($name);
+        $agent = $this->pool->create($name);
+
+        return $agent->run($this->buildMessage($message, $context), $profile->options);
+    }
+
+    public function canDispatch(string $toolName): bool
+    {
+        if (! str_starts_with($toolName, self::TOOL_PREFIX)) {
+            return false;
+        }
+
+        return $this->pool->has($this->agentNameFromTool($toolName));
+    }
+
+    #[Override]
+    public function dispatch(ToolCall $toolCall): ToolResult
+    {
+        if (! str_starts_with($toolCall->name, self::TOOL_PREFIX)) {
+            return $this->fallback?->dispatch($toolCall)
+                ?? ToolResult::error($toolCall->id, sprintf('Unknown tool: %s', $toolCall->name));
+        }
+
+        $agentName = $this->agentNameFromTool($toolCall->name);
+        if (! $this->pool->has($agentName)) {
+            return ToolResult::error($toolCall->id, sprintf('Unknown agent: %s', $agentName));
+        }
+
+        $message = $toolCall->input['message'] ?? null;
+        if (! is_string($message)) {
+            return ToolResult::error($toolCall->id, 'Agent tool input "message" must be a string.');
+        }
+
+        $context = $this->contextFromInput($toolCall->input['context'] ?? []);
+        if ($context === null) {
+            return ToolResult::error($toolCall->id, 'Agent tool input "context" must be an object.');
+        }
+
+        $response = $this->ask($agentName, $message, $context);
+        if (! $response->completed) {
+            return ToolResult::error($toolCall->id, sprintf(
+                'Subagent stopped: %s',
+                $response->stopReason,
+            ));
+        }
+
+        return ToolResult::success($toolCall->id, $response->getText());
+    }
+
+    private function agentNameFromTool(string $toolName): string
+    {
+        return substr($toolName, strlen(self::TOOL_PREFIX));
+    }
+
+    /** @return array<string, mixed>|null */
+    private function contextFromInput(mixed $context): array|null
+    {
+        if (! is_array($context)) {
+            return null;
+        }
+
+        foreach (array_keys($context) as $key) {
+            if (! is_string($key)) {
+                return null;
+            }
+        }
+
+        /** @var array<string, mixed> $context */
+        return $context;
+    }
+
+    /** @param array<string, mixed> $context */
+    private function buildMessage(string $message, array $context): string
+    {
+        if ($context === []) {
+            return $message;
+        }
+
+        $encodedContext = json_encode($context, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return $message . "\n\nContext:\n" . $encodedContext;
+    }
+}

--- a/src/Runtime/AgentFactory.php
+++ b/src/Runtime/AgentFactory.php
@@ -39,9 +39,34 @@ final class AgentFactory
     public function addResources(array $uris): self
     {
         $tools = $this->collector->collect($uris);
+
+        return $this->addTools($tools);
+    }
+
+    /**
+     * Add already-built tools.
+     *
+     * @param list<Tool> $tools
+     *
+     * @return $this
+     */
+    public function addTools(array $tools): self
+    {
         foreach ($tools as $tool) {
             $this->tools[] = $tool;
         }
+
+        return $this;
+    }
+
+    /**
+     * Add named subagents as tools.
+     *
+     * @return $this
+     */
+    public function addSubagents(AgentPool $pool): self
+    {
+        $this->addTools($pool->getTools());
 
         return $this;
     }

--- a/src/Runtime/AgentInterface.php
+++ b/src/Runtime/AgentInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Runtime;
 
+use InvalidArgumentException;
+
 /**
  * Agent runtime for managing LLM conversation loop
  */
@@ -11,8 +13,10 @@ interface AgentInterface
 {
     /**
      * Run the agent with a user message
+     *
+     * @throws InvalidArgumentException When options reference unknown tools.
      */
-    public function run(string $userMessage): AgentResponse;
+    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse;
 
     /**
      * Clear conversation history to start a new conversation

--- a/src/Runtime/AgentOptions.php
+++ b/src/Runtime/AgentOptions.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Llm\LlmResponse;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
+use UnexpectedValueException;
+
+use function array_fill_keys;
+use function implode;
+use function sprintf;
+
+/**
+ * Per-run agent options
+ */
+final readonly class AgentOptions
+{
+    /**
+     * @param list<string>|null              $enabledTools
+     * @param list<InputProcessorInterface>  $inputProcessors
+     * @param list<OutputProcessorInterface> $outputProcessors
+     */
+    public function __construct(
+        public array|null $enabledTools = null,
+        public array $inputProcessors = [],
+        public array $outputProcessors = [],
+    ) {
+    }
+
+    /** @param list<string> $toolNames */
+    public static function withTools(array $toolNames): self
+    {
+        return new self(enabledTools: $toolNames);
+    }
+
+    /**
+     * @param list<InputProcessorInterface>  $inputProcessors
+     * @param list<OutputProcessorInterface> $outputProcessors
+     * @param list<string>|null              $enabledTools
+     */
+    public static function withProcessors(
+        array $inputProcessors = [],
+        array $outputProcessors = [],
+        array|null $enabledTools = null,
+    ): self {
+        return new self($enabledTools, $inputProcessors, $outputProcessors);
+    }
+
+    public function filtersTools(): bool
+    {
+        return $this->enabledTools !== null;
+    }
+
+    public function enforcesToolList(): bool
+    {
+        return $this->enabledTools !== null || $this->inputProcessors !== [];
+    }
+
+    /**
+     * @param list<Tool> $tools
+     *
+     * @return list<Tool>
+     *
+     * @throws InvalidArgumentException When an enabled tool name is unknown.
+     */
+    public function filterTools(array $tools): array
+    {
+        if ($this->enabledTools === null) {
+            return $tools;
+        }
+
+        $knownTools = [];
+        foreach ($tools as $tool) {
+            $knownTools[$tool->name] = true;
+        }
+
+        $unknownTools = [];
+        foreach ($this->enabledTools as $toolName) {
+            if (isset($knownTools[$toolName])) {
+                continue;
+            }
+
+            $unknownTools[] = $toolName;
+        }
+
+        if ($unknownTools !== []) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown tool(s): %s',
+                implode(', ', $unknownTools),
+            ));
+        }
+
+        $enabledTools = array_fill_keys($this->enabledTools, true);
+        $filteredTools = [];
+        foreach ($tools as $tool) {
+            if (! isset($enabledTools[$tool->name])) {
+                continue;
+            }
+
+            $filteredTools[] = $tool;
+        }
+
+        return $filteredTools;
+    }
+
+    public function processRequest(LlmRequest $request): LlmRequest
+    {
+        foreach ($this->inputProcessors as $processor) {
+            $request = $processor->process($request);
+        }
+
+        return $request;
+    }
+
+    public function processResponse(LlmResponse $response, LlmRequest $request): LlmResponse
+    {
+        $output = $response;
+        foreach ($this->outputProcessors as $processor) {
+            $output = $processor->process($output, $request);
+            if (! $output instanceof LlmResponse) {
+                throw new UnexpectedValueException('Output processor must return LlmResponse for non-streaming calls.');
+            }
+        }
+
+        return $output;
+    }
+
+    public function processStreamEvent(StreamEvent $event, LlmRequest $request): StreamEvent
+    {
+        $output = $event;
+        foreach ($this->outputProcessors as $processor) {
+            $output = $processor->process($output, $request);
+            if (! $output instanceof StreamEvent) {
+                throw new UnexpectedValueException('Output processor must return StreamEvent for streaming calls.');
+            }
+        }
+
+        return $output;
+    }
+}

--- a/src/Runtime/AgentPool.php
+++ b/src/Runtime/AgentPool.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Llm\LlmClientInterface;
+use BEAR\ToolUse\Schema\Tool;
+use BEAR\ToolUse\Schema\ToolCollectorInterface;
+use InvalidArgumentException;
+
+use function sprintf;
+
+/**
+ * Registry and factory for named subagents
+ */
+final class AgentPool
+{
+    /** @var array<string, AgentProfile> */
+    private array $profiles = [];
+
+    public function __construct(
+        private readonly LlmClientInterface $client,
+        private readonly DispatcherInterface $dispatcher,
+        private readonly ToolCollectorInterface $collector,
+        private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
+    ) {
+    }
+
+    public function register(AgentProfile $profile): self
+    {
+        $this->profiles[$profile->name] = $profile;
+
+        return $this;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->profiles[$name]);
+    }
+
+    public function get(string $name): AgentProfile
+    {
+        if (! isset($this->profiles[$name])) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown agent: %s',
+                $name,
+            ));
+        }
+
+        return $this->profiles[$name];
+    }
+
+    public function create(string $name): AgentInterface
+    {
+        $profile = $this->get($name);
+        $tools = $this->collector->collect($profile->resources);
+
+        return new Agent(
+            client: $this->client,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: $profile->systemPrompt,
+            maxIterations: $profile->maxIterations,
+            confirmationHandler: $this->confirmationHandler,
+        );
+    }
+
+    /** @return list<Tool> */
+    public function getTools(): array
+    {
+        $tools = [];
+        foreach ($this->profiles as $profile) {
+            $tools[] = $profile->toTool();
+        }
+
+        return $tools;
+    }
+}

--- a/src/Runtime/AgentProfile.php
+++ b/src/Runtime/AgentProfile.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
+
+use function preg_match;
+use function sprintf;
+
+/**
+ * Configuration for a named subagent
+ */
+final readonly class AgentProfile
+{
+    /** @param list<string> $resources */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public string $systemPrompt,
+        public array $resources = [],
+        public int $maxIterations = 10,
+        public AgentOptions|null $options = null,
+    ) {
+        if (preg_match('/^[A-Za-z][A-Za-z0-9_]*$/', $name) !== 1) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid agent name: %s',
+                $name,
+            ));
+        }
+    }
+
+    public function toolName(): string
+    {
+        return 'ask_' . $this->name;
+    }
+
+    public function toTool(): Tool
+    {
+        return new Tool(
+            name: $this->toolName(),
+            description: $this->description,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [
+                    'message' => [
+                        'type' => 'string',
+                        'description' => 'Question or task for the subagent.',
+                    ],
+                    'context' => [
+                        'type' => 'object',
+                        'description' => 'Additional context for the subagent.',
+                    ],
+                ],
+                'required' => ['message'],
+            ],
+        );
+    }
+}

--- a/src/Runtime/InputProcessorInterface.php
+++ b/src/Runtime/InputProcessorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+/**
+ * Processes an LLM request before each LLM call
+ */
+interface InputProcessorInterface
+{
+    public function process(LlmRequest $request): LlmRequest;
+}

--- a/src/Runtime/LlmRequest.php
+++ b/src/Runtime/LlmRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\Tool;
+
+/**
+ * Request passed to an LLM call
+ */
+final readonly class LlmRequest
+{
+    /**
+     * @param list<Message> $messages
+     * @param list<Tool>    $tools
+     */
+    public function __construct(
+        public string $systemPrompt,
+        public array $messages,
+        public array $tools,
+    ) {
+    }
+
+    public function withSystemPrompt(string $systemPrompt): self
+    {
+        return new self($systemPrompt, $this->messages, $this->tools);
+    }
+
+    /** @param list<Message> $messages */
+    public function withMessages(array $messages): self
+    {
+        return new self($this->systemPrompt, $messages, $this->tools);
+    }
+
+    /** @param list<Tool> $tools */
+    public function withTools(array $tools): self
+    {
+        return new self($this->systemPrompt, $this->messages, $tools);
+    }
+}

--- a/src/Runtime/OutputProcessorInterface.php
+++ b/src/Runtime/OutputProcessorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Llm\LlmResponse;
+use BEAR\ToolUse\Llm\StreamEvent;
+
+/**
+ * Processes an LLM response after each LLM call
+ */
+interface OutputProcessorInterface
+{
+    public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent;
+}

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -31,7 +31,6 @@ final class StreamingAgent implements StreamingAgentInterface
 {
     /** @var list<Message> */
     public array $messages = [];
-    private readonly ToolList $toolList;
 
     /** @param list<Tool> $tools */
     public function __construct(
@@ -41,23 +40,28 @@ final class StreamingAgent implements StreamingAgentInterface
         private readonly string $systemPrompt,
         private readonly int $maxIterations = 10,
     ) {
-        $this->toolList = new ToolList($this->tools);
     }
 
     /** @return Generator<int, AgentEvent, mixed, void> */
     #[Override]
-    public function runStream(string $userMessage): Generator
+    public function runStream(string $userMessage, AgentOptions|null $options = null): Generator
     {
+        $runTools = $this->resolveTools($options);
+        $enforceToolList = $options?->enforcesToolList() ?? false;
+
         $this->messages[] = Message::user($userMessage);
         $fullText = '';
         $hadPreviousText = false;
 
         for ($i = 0; $i < $this->maxIterations; $i++) {
+            $request = $this->createRequest($runTools, $options);
             $stream = $this->client->chatStream(
-                system: $this->systemPrompt,
-                messages: $this->messages,
-                tools: $this->tools,
+                system: $request->systemPrompt,
+                messages: $request->messages,
+                tools: $request->tools,
             );
+            $stream = $this->processStream($stream, $request, $options);
+            $requestToolList = new ToolList($request->tools);
 
             $consumeGen = $this->consumeStream($stream, $hadPreviousText, $fullText);
             foreach ($consumeGen as $event) {
@@ -78,7 +82,12 @@ final class StreamingAgent implements StreamingAgentInterface
             if ($state->stopReason === 'tool_use' && $state->pendingToolCalls !== []) {
                 $this->messages[] = Message::assistant($state->contentBlocks);
 
-                $dispatchGen = $this->dispatchPendingToolCalls($state->pendingToolCalls, $state->currentText);
+                $dispatchGen = $this->dispatchPendingToolCalls(
+                    $state->pendingToolCalls,
+                    $state->currentText,
+                    $requestToolList,
+                    $enforceToolList,
+                );
                 while ($dispatchGen->valid()) {
                     /** @var AgentEvent $currentEvent */
                     $currentEvent = $dispatchGen->current();
@@ -123,6 +132,32 @@ final class StreamingAgent implements StreamingAgentInterface
         $this->messages[] = Message::assistant($state->contentBlocks);
     }
 
+    /** @return list<Tool> */
+    private function resolveTools(AgentOptions|null $options): array
+    {
+        return $options?->filterTools($this->tools) ?? $this->tools;
+    }
+
+    /** @param list<Tool> $tools */
+    private function createRequest(array $tools, AgentOptions|null $options): LlmRequest
+    {
+        $request = new LlmRequest($this->systemPrompt, $this->messages, $tools);
+
+        return $options?->processRequest($request) ?? $request;
+    }
+
+    /**
+     * @param Generator<int, StreamEvent, mixed, void> $stream
+     *
+     * @return Generator<int, StreamEvent, mixed, void>
+     */
+    private function processStream(Generator $stream, LlmRequest $request, AgentOptions|null $options): Generator
+    {
+        foreach ($stream as $event) {
+            yield $options?->processStreamEvent($event, $request) ?? $event;
+        }
+    }
+
     /**
      * Consume stream events and yield AgentEvents
      *
@@ -151,8 +186,12 @@ final class StreamingAgent implements StreamingAgentInterface
      *
      * @return Generator<int, AgentEvent, bool, list<ToolResult>>
      */
-    private function dispatchPendingToolCalls(array $pendingToolCalls, string $currentText): Generator
-    {
+    private function dispatchPendingToolCalls(
+        array $pendingToolCalls,
+        string $currentText,
+        ToolList $toolList,
+        bool $enforceToolList,
+    ): Generator {
         $toolResults = [];
         foreach ($pendingToolCalls as $pending) {
             /** @var array<string, mixed> $input */
@@ -163,7 +202,15 @@ final class StreamingAgent implements StreamingAgentInterface
                 input: $input,
             );
 
-            if ($this->toolList->isConfirmable($toolCall->name)) {
+            if ($enforceToolList && ! $toolList->has($toolCall->name)) {
+                $toolResults[] = ToolResult::error($toolCall->id, 'Tool is not enabled: ' . $toolCall->name);
+
+                yield AgentEvent::toolResult($pending->name);
+
+                continue;
+            }
+
+            if ($toolList->isConfirmable($toolCall->name)) {
                 /** @var bool $approved */
                 $approved = yield AgentEvent::confirmationRequired(
                     $toolCall->name,

--- a/src/Runtime/StreamingAgentInterface.php
+++ b/src/Runtime/StreamingAgentInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ToolUse\Runtime;
 
 use Generator;
+use InvalidArgumentException;
 
 /**
  * Streaming agent runtime
@@ -15,8 +16,10 @@ interface StreamingAgentInterface
      * Run the agent with streaming output
      *
      * @return Generator<int, AgentEvent, mixed, void>
+     *
+     * @throws InvalidArgumentException When options reference unknown tools.
      */
-    public function runStream(string $userMessage): Generator;
+    public function runStream(string $userMessage, AgentOptions|null $options = null): Generator;
 
     /**
      * Clear conversation history

--- a/src/Runtime/ToolList.php
+++ b/src/Runtime/ToolList.php
@@ -14,13 +14,18 @@ use function array_key_exists;
 final readonly class ToolList
 {
     /** @var array<string, bool> */
+    private array $available;
+
+    /** @var array<string, bool> */
     private array $confirmable;
 
     /** @param list<Tool> $tools */
     public function __construct(array $tools)
     {
+        $available = [];
         $confirmable = [];
         foreach ($tools as $tool) {
+            $available[$tool->name] = true;
             if (! $tool->confirm) {
                 continue;
             }
@@ -28,7 +33,13 @@ final readonly class ToolList
             $confirmable[$tool->name] = true;
         }
 
+        $this->available = $available;
         $this->confirmable = $confirmable;
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->available);
     }
 
     public function isConfirmable(string $name): bool

--- a/tests/Fake/FakeInputProcessor.php
+++ b/tests/Fake/FakeInputProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\Message;
+use Override;
+
+/**
+ * Fake input processor for testing
+ */
+final class FakeInputProcessor implements InputProcessorInterface
+{
+    public int $calls = 0;
+
+    public function __construct(
+        private readonly string $systemSuffix = '',
+        private readonly string $memoryText = 'memory',
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $this->calls++;
+
+        return $request
+            ->withSystemPrompt($request->systemPrompt . $this->systemSuffix)
+            ->withMessages([...$request->messages, Message::user($this->memoryText)]);
+    }
+}

--- a/tests/Fake/FakeOutputProcessor.php
+++ b/tests/Fake/FakeOutputProcessor.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Llm\LlmResponse;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\OutputProcessorInterface;
+use Override;
+
+/**
+ * Fake output processor for testing
+ */
+final class FakeOutputProcessor implements OutputProcessorInterface
+{
+    public int $calls = 0;
+
+    public function __construct(
+        private readonly string $replacementText,
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+    {
+        $this->calls++;
+
+        if ($output instanceof LlmResponse) {
+            return new LlmResponse(
+                $output->stopReason,
+                [['type' => 'text', 'text' => $this->replacementText]],
+                $output->toolCalls,
+            );
+        }
+
+        if ($output->type !== StreamEvent::TEXT_DELTA) {
+            return $output;
+        }
+
+        return new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => $this->replacementText]);
+    }
+}

--- a/tests/Fake/FakeToolFilteringInputProcessor.php
+++ b/tests/Fake/FakeToolFilteringInputProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Schema\Tool;
+use Override;
+
+/**
+ * Fake tool filtering input processor for testing
+ */
+final readonly class FakeToolFilteringInputProcessor implements InputProcessorInterface
+{
+    public function __construct(
+        private string $enabledTool,
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $tools = [];
+        foreach ($request->tools as $tool) {
+            if ($tool->name !== $this->enabledTool) {
+                continue;
+            }
+
+            $tools[] = $tool;
+        }
+
+        /** @var list<Tool> $tools */
+        return $request->withTools($tools);
+    }
+}

--- a/tests/Runtime/AgentOptionsTest.php
+++ b/tests/Runtime/AgentOptionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AgentOptions::class)]
+final class AgentOptionsTest extends TestCase
+{
+    public function testNullEnabledToolsDoesNotFilter(): void
+    {
+        $tools = [
+            $this->tool('article_get'),
+            $this->tool('article_post'),
+        ];
+
+        $options = new AgentOptions();
+
+        $this->assertSame($tools, $options->filterTools($tools));
+        $this->assertFalse($options->filtersTools());
+    }
+
+    public function testWithToolsFiltersInOriginalToolOrder(): void
+    {
+        $tools = [
+            $this->tool('article_get'),
+            $this->tool('article_post'),
+            $this->tool('article_delete'),
+        ];
+
+        $options = AgentOptions::withTools(['article_delete', 'article_get']);
+
+        $filtered = $options->filterTools($tools);
+
+        $this->assertTrue($options->filtersTools());
+        $this->assertSame(['article_get', 'article_delete'], [
+            $filtered[0]->name,
+            $filtered[1]->name,
+        ]);
+    }
+
+    public function testEmptyEnabledToolsFiltersAllTools(): void
+    {
+        $options = AgentOptions::withTools([]);
+
+        $this->assertSame([], $options->filterTools([$this->tool('article_get')]));
+        $this->assertTrue($options->filtersTools());
+    }
+
+    public function testUnknownToolThrows(): void
+    {
+        $options = AgentOptions::withTools(['missing_tool']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown tool(s): missing_tool');
+
+        $options->filterTools([$this->tool('article_get')]);
+    }
+
+    private function tool(string $name): Tool
+    {
+        return new Tool($name, 'Test tool', [
+            'type' => 'object',
+            'properties' => [],
+            'required' => [],
+        ]);
+    }
+}

--- a/tests/Runtime/AgentPoolTest.php
+++ b/tests/Runtime/AgentPoolTest.php
@@ -8,9 +8,11 @@ use BEAR\Resource\FactoryInterface;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
 use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Schema\SchemaConverter;
 use BEAR\ToolUse\Schema\ToolCollector;
@@ -25,6 +27,7 @@ use function array_map;
 #[CoversClass(AgentProfile::class)]
 #[CoversClass(AgentPool::class)]
 #[CoversClass(AgentDelegator::class)]
+#[CoversClass(AgentFactory::class)]
 final class AgentPoolTest extends TestCase
 {
     public function testRegisterAndGetProfile(): void
@@ -148,6 +151,60 @@ final class AgentPoolTest extends TestCase
         $this->assertSame("Review this.\n\nContext:\n{\"id\":1}", $llmClient->calls[0]['messages'][0]->content[0]['text']);
     }
 
+    public function testDelegatorCanDispatchKnownSubagentToolOnly(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $this->assertFalse($delegator->canDispatch('article_get'));
+        $this->assertTrue($delegator->canDispatch('ask_critic'));
+        $this->assertFalse($delegator->canDispatch('ask_missing'));
+    }
+
+    public function testDelegatorFallsBackForNonAgentTool(): void
+    {
+        [$pool] = $this->createPool();
+        $fallback = new class implements DispatcherInterface {
+            public function dispatch(ToolCall $toolCall): ToolResult
+            {
+                return ToolResult::success($toolCall->id, 'fallback result');
+            }
+        };
+        $delegator = new AgentDelegator($pool, $fallback);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'article_get', []));
+
+        $this->assertFalse($result->isError);
+        $this->assertSame('fallback result', $result->content);
+    }
+
+    public function testDelegatorReturnsUnknownToolWithoutFallback(): void
+    {
+        [$pool] = $this->createPool();
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'article_get', []));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Unknown tool: article_get', $result->content);
+    }
+
+    public function testDelegatorReturnsUnknownAgentForAskTool(): void
+    {
+        [$pool] = $this->createPool();
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_missing', ['message' => 'Hi']));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Unknown agent: missing', $result->content);
+    }
+
     public function testDelegatorReturnsErrorForInvalidToolInput(): void
     {
         [$pool] = $this->createPool();
@@ -162,6 +219,49 @@ final class AgentPoolTest extends TestCase
 
         $this->assertTrue($result->isError);
         $this->assertSame('Agent tool input "message" must be a string.', $result->content);
+    }
+
+    public function testDelegatorReturnsErrorForInvalidContextInput(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $stringContext = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', [
+            'message' => 'Review this.',
+            'context' => 'invalid',
+        ]));
+        $listContext = $delegator->dispatch(new ToolCall('call_2', 'ask_critic', [
+            'message' => 'Review this.',
+            'context' => ['invalid'],
+        ]));
+
+        $this->assertTrue($stringContext->isError);
+        $this->assertSame('Agent tool input "context" must be an object.', $stringContext->content);
+        $this->assertTrue($listContext->isError);
+        $this->assertSame('Agent tool input "context" must be an object.', $listContext->content);
+    }
+
+    public function testDelegatorReturnsErrorWhenSubagentDoesNotComplete(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueMaxTokensResponse('Partial.');
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', ['message' => 'Review this.']));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Subagent stopped: max_tokens', $result->content);
     }
 
     public function testMainAgentCanCallSubagentAsTool(): void

--- a/tests/Runtime/AgentPoolTest.php
+++ b/tests/Runtime/AgentPoolTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\Resource\FactoryInterface;
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeLlmClient;
+use BEAR\ToolUse\Schema\SchemaConverter;
+use BEAR\ToolUse\Schema\ToolCollector;
+use InvalidArgumentException;
+use phpDocumentor\Reflection\DocBlockFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+use function array_map;
+
+#[CoversClass(AgentProfile::class)]
+#[CoversClass(AgentPool::class)]
+#[CoversClass(AgentDelegator::class)]
+final class AgentPoolTest extends TestCase
+{
+    public function testRegisterAndGetProfile(): void
+    {
+        [$pool] = $this->createPool();
+        $profile = new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        );
+
+        $pool->register($profile);
+
+        $this->assertTrue($pool->has('critic'));
+        $this->assertSame($profile, $pool->get('critic'));
+    }
+
+    public function testUnknownAgentThrows(): void
+    {
+        [$pool] = $this->createPool();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown agent: missing');
+
+        $pool->get('missing');
+    }
+
+    public function testInvalidProfileNameThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid agent name: ask-critic');
+
+        new AgentProfile(
+            name: 'ask-critic',
+            description: 'Invalid',
+            systemPrompt: 'Invalid',
+        );
+    }
+
+    public function testProfileCreatesToolDefinition(): void
+    {
+        $profile = new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        );
+
+        $tool = $profile->toTool();
+
+        $this->assertSame('ask_critic', $tool->name);
+        $this->assertSame('Review design risks', $tool->description);
+        $this->assertSame(['message'], $tool->inputSchema['required']);
+    }
+
+    public function testDelegatorAskUsesProfileResources(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+            resources: ['app://self/article'],
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueTextResponse('Risk found.');
+
+        $response = $delegator->ask('critic', 'Review this.');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Risk found.', $response->getText());
+        $this->assertSame('You are a critic.', $llmClient->calls[0]['system']);
+        $this->assertSame(['article_get'], array_map(
+            static fn ($tool): string => $tool->name,
+            $llmClient->calls[0]['tools'],
+        ));
+    }
+
+    public function testDelegatorAskIsolatesSubagentHistoryPerCall(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueTextResponse('First.');
+        $llmClient->queueTextResponse('Second.');
+
+        $delegator->ask('critic', 'First task.');
+        $delegator->ask('critic', 'Second task.');
+
+        $this->assertCount(1, $llmClient->calls[0]['messages']);
+        $this->assertCount(1, $llmClient->calls[1]['messages']);
+        $this->assertSame('First task.', $llmClient->calls[0]['messages'][0]->content[0]['text']);
+        $this->assertSame('Second task.', $llmClient->calls[1]['messages'][0]->content[0]['text']);
+    }
+
+    public function testDelegatorDispatchesSubagentToolCall(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueTextResponse('Risk found.');
+
+        $result = $delegator->dispatch(new ToolCall(
+            id: 'call_1',
+            name: 'ask_critic',
+            input: ['message' => 'Review this.', 'context' => ['id' => 1]],
+        ));
+
+        $this->assertFalse($result->isError);
+        $this->assertSame('Risk found.', $result->content);
+        $this->assertSame("Review this.\n\nContext:\n{\"id\":1}", $llmClient->calls[0]['messages'][0]->content[0]['text']);
+    }
+
+    public function testDelegatorReturnsErrorForInvalidToolInput(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', []));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Agent tool input "message" must be a string.', $result->content);
+    }
+
+    public function testMainAgentCanCallSubagentAsTool(): void
+    {
+        [$pool, $llmClient, $resourceDispatcher] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $mainAgent = new Agent(
+            client: $llmClient,
+            dispatcher: new AgentDelegator($pool, $resourceDispatcher),
+            tools: $pool->getTools(),
+            systemPrompt: 'You are a main agent.',
+            maxIterations: 5,
+        );
+
+        $llmClient->queueToolUseResponse('call_1', 'ask_critic', ['message' => 'Review this.']);
+        $llmClient->queueTextResponse('Risk found.');
+        $llmClient->queueTextResponse('Delegation complete.');
+
+        $response = $mainAgent->run('Use critic.');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Delegation complete.', $response->getText());
+        $this->assertSame('You are a main agent.', $llmClient->calls[0]['system']);
+        $this->assertSame('You are a critic.', $llmClient->calls[1]['system']);
+        $this->assertSame('Risk found.', $llmClient->calls[2]['messages'][2]->content[0]['content']);
+    }
+
+    public function testAgentFactoryAddsSubagentTools(): void
+    {
+        [$pool, $llmClient, $resourceDispatcher, $collector, $registry] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+
+        $factory = new AgentFactory($llmClient, $resourceDispatcher, $collector, $registry);
+        $factory->addSubagents($pool);
+
+        $this->assertSame('ask_critic', $factory->getTools()[0]->name);
+    }
+
+    /** @return array{AgentPool, FakeLlmClient, Dispatcher, ToolCollector, ToolRegistry} */
+    private function createPool(): array
+    {
+        $llmClient = new FakeLlmClient();
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $resourceFactory = $injector->getInstance(FactoryInterface::class);
+        $registry = new ToolRegistry();
+        $converter = new SchemaConverter(DocBlockFactory::createInstance());
+        $collector = new ToolCollector($converter, $registry, $resourceFactory);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
+        $pool = new AgentPool($llmClient, $dispatcher, $collector);
+
+        return [$pool, $llmClient, $dispatcher, $collector, $registry];
+    }
+}

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeInputProcessor;
+use BEAR\ToolUse\Fake\FakeLlmClient;
+use BEAR\ToolUse\Fake\FakeOutputProcessor;
+use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
+use BEAR\ToolUse\Fake\FakeToolFilteringInputProcessor;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+use function iterator_to_array;
+
+#[CoversClass(Agent::class)]
+#[CoversClass(StreamingAgent::class)]
+#[CoversClass(AgentOptions::class)]
+#[CoversClass(LlmRequest::class)]
+final class AgentProcessorTest extends TestCase
+{
+    public function testInputProcessorChangesAgentRequest(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new FakeInputProcessor(' Use memory.', 'remember user context');
+
+        $llmClient->queueTextResponse('Done.');
+
+        $agent->run('Hello', AgentOptions::withProcessors(inputProcessors: [$processor]));
+
+        $this->assertSame(1, $processor->calls);
+        $this->assertSame('You are a helpful assistant. Use memory.', $llmClient->calls[0]['system']);
+        $this->assertSame('remember user context', $llmClient->calls[0]['messages'][1]->content[0]['text']);
+    }
+
+    public function testOutputProcessorChangesAgentResponse(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new FakeOutputProcessor('Processed response.');
+
+        $llmClient->queueTextResponse('Raw response.');
+
+        $response = $agent->run('Hello', AgentOptions::withProcessors(outputProcessors: [$processor]));
+
+        $this->assertSame(1, $processor->calls);
+        $this->assertSame('Processed response.', $response->getText());
+    }
+
+    public function testProcessorsRunOnEveryToolLoopIteration(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $inputProcessor = new FakeInputProcessor(memoryText: 'memory');
+        $outputProcessor = new FakeOutputProcessor('processed');
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+        $llmClient->queueTextResponse('Done.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(
+            inputProcessors: [$inputProcessor],
+            outputProcessors: [$outputProcessor],
+        ));
+
+        $this->assertSame(2, $inputProcessor->calls);
+        $this->assertSame(2, $outputProcessor->calls);
+        $this->assertSame('memory', $llmClient->calls[1]['messages'][3]->content[0]['text']);
+    }
+
+    public function testInputProcessorFilteredToolIsEnforced(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        $llmClient->queueTextResponse('Recovered.');
+
+        $agent->run('Try error tool', AgentOptions::withProcessors(
+            inputProcessors: [new FakeToolFilteringInputProcessor('article_get')],
+        ));
+
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testStreamingProcessorsAreApplied(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgent($llmClient);
+        $inputProcessor = new FakeInputProcessor(' Stream.', 'stream memory');
+        $outputProcessor = new FakeOutputProcessor('Processed');
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Raw']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($agent->runStream('Hi', AgentOptions::withProcessors(
+            inputProcessors: [$inputProcessor],
+            outputProcessors: [$outputProcessor],
+        )));
+
+        $this->assertSame(1, $inputProcessor->calls);
+        $this->assertSame(3, $outputProcessor->calls);
+        $this->assertSame('You are a helpful assistant. Stream.', $llmClient->calls[0]['system']);
+        $this->assertSame('stream memory', $llmClient->calls[0]['messages'][1]->content[0]['text']);
+        $this->assertSame('Processed', $events[0]->data['text']);
+        $this->assertSame('Processed', $events[1]->data['fullText']);
+    }
+
+    private function createAgent(FakeLlmClient $llmClient): Agent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [$this->articleTool()],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    private function createStreamingAgent(FakeStreamingLlmClient $llmClient): StreamingAgent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+
+        return new StreamingAgent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [$this->articleTool()],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    private function createAgentWithArticleAndErrorTools(FakeLlmClient $llmClient): Agent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [
+                $this->articleTool(),
+                new Tool('error_get', 'Get error resource', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    /** @return array{ResourceInterface, ToolRegistry} */
+    private function resourceAndRegistry(): array
+    {
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+
+        return [
+            $injector->getInstance(ResourceInterface::class),
+            new ToolRegistry(),
+        ];
+    }
+
+    private function articleTool(): Tool
+    {
+        return new Tool('article_get', 'Get an article', [
+            'type' => 'object',
+            'properties' => ['id' => ['type' => 'integer']],
+            'required' => ['id'],
+        ]);
+    }
+}

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -14,11 +14,14 @@ use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Fake\FakeOutputProcessor;
 use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Fake\FakeToolFilteringInputProcessor;
+use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Schema\Tool;
+use Override;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
+use UnexpectedValueException;
 
 use function iterator_to_array;
 
@@ -55,6 +58,26 @@ final class AgentProcessorTest extends TestCase
 
         $this->assertSame(1, $processor->calls);
         $this->assertSame('Processed response.', $response->getText());
+    }
+
+    public function testAgentOutputProcessorMustReturnLlmResponse(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                return new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'wrong type']);
+            }
+        };
+
+        $llmClient->queueTextResponse('Raw response.');
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must return LlmResponse for non-streaming calls.');
+
+        $agent->run('Hello', AgentOptions::withProcessors(outputProcessors: [$processor]));
     }
 
     public function testProcessorsRunOnEveryToolLoopIteration(): void
@@ -121,6 +144,32 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame('stream memory', $llmClient->calls[0]['messages'][1]->content[0]['text']);
         $this->assertSame('Processed', $events[0]->data['text']);
         $this->assertSame('Processed', $events[1]->data['fullText']);
+    }
+
+    public function testStreamingOutputProcessorMustReturnStreamEvent(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                return new LlmResponse('end_turn', [['type' => 'text', 'text' => 'wrong type']], []);
+            }
+        };
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Raw']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must return StreamEvent for streaming calls.');
+
+        iterator_to_array($agent->runStream('Hi', AgentOptions::withProcessors(outputProcessors: [$processor])));
     }
 
     private function createAgent(FakeLlmClient $llmClient): Agent

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -13,11 +13,15 @@ use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
+use function array_map;
+
 #[CoversClass(Agent::class)]
+#[CoversClass(AgentOptions::class)]
 #[CoversClass(AgentResponse::class)]
 #[CoversClass(Message::class)]
 final class AgentTest extends TestCase
@@ -121,6 +125,65 @@ final class AgentTest extends TestCase
 
         $this->assertTrue($response->completed);
         $this->assertSame('I found the article!', $response->getText());
+    }
+
+    public function testRunWithToolFilteringPassesOnlyEnabledTools(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueTextResponse('Done.');
+
+        $response = $agent->run('Use limited tools', AgentOptions::withTools(['article_get']));
+
+        $this->assertTrue($response->completed);
+        $this->assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[0]['tools'],
+        ));
+    }
+
+    public function testRunWithToolFilteringPassesOnlyEnabledToolsAfterToolUse(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+        $llmClient->queueTextResponse('Done.');
+
+        $response = $agent->run('Use limited tools', AgentOptions::withTools(['article_get']));
+
+        $this->assertTrue($response->completed);
+        $this->assertCount(2, $llmClient->calls);
+        $this->assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[1]['tools'],
+        ));
+    }
+
+    public function testRunWithUnknownToolFilterThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown tool(s): missing_tool');
+
+        $this->agent->run('Use missing tool', AgentOptions::withTools(['missing_tool']));
+    }
+
+    public function testRunWithDisabledToolCallReturnsErrorWithoutDispatching(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        $llmClient->queueTextResponse('The disabled tool was not used.');
+
+        $response = $agent->run('Try disabled tool', AgentOptions::withTools(['article_get']));
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('The disabled tool was not used.', $response->getText());
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
     }
 
     public function testMessageUser(): void
@@ -429,5 +492,34 @@ final class AgentTest extends TestCase
         $this->assertTrue($toolResultMessage->content[0]['is_error']);
         $this->assertStringContainsString('400:', $toolResultMessage->content[0]['content']);
         $this->assertStringContainsString('Validation failed', $toolResultMessage->content[0]['content']);
+    }
+
+    private function createAgentWithArticleAndErrorTools(FakeLlmClient $llmClient): Agent
+    {
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: [
+                new Tool('article_get', 'Get an article', [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id'],
+                ]),
+                new Tool('error_get', 'Get error resource', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
     }
 }

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -13,6 +13,7 @@ use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Fake\FakeThrowingDispatcher;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -23,6 +24,7 @@ use function iterator_to_array;
 use function json_encode;
 
 #[CoversClass(StreamingAgent::class)]
+#[CoversClass(AgentOptions::class)]
 #[CoversClass(StreamContentAccumulator::class)]
 #[CoversClass(StreamIterationState::class)]
 #[CoversClass(AgentEvent::class)]
@@ -122,6 +124,94 @@ final class StreamingAgentTest extends TestCase
         self::assertSame('article_get', $events[1]->data['toolName']);
         self::assertSame('article_get', $events[2]->data['toolName']);
         self::assertSame("Looking up...\nFound it!", $events[5]->data['fullText']);
+    }
+
+    public function testRunStreamWithToolFilteringPassesOnlyEnabledTools(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Done']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($agent->runStream('Use limited tools', AgentOptions::withTools(['article_get'])));
+
+        self::assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[0]['tools'],
+        ));
+    }
+
+    public function testRunStreamWithToolFilteringPassesOnlyEnabledToolsAfterToolUse(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleAndErrorTools($llmClient);
+        $toolInput = json_encode(['id' => 1]);
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'article_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Done']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($agent->runStream('Use limited tools', AgentOptions::withTools(['article_get'])));
+
+        self::assertCount(2, $llmClient->calls);
+        self::assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[1]['tools'],
+        ));
+    }
+
+    public function testRunStreamWithUnknownToolFilterThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown tool(s): missing_tool');
+
+        iterator_to_array($this->agent->runStream('Use missing tool', AgentOptions::withTools(['missing_tool'])));
+    }
+
+    public function testRunStreamWithDisabledToolCallReturnsErrorWithoutDispatching(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleAndErrorTools($llmClient);
+        $toolInput = json_encode([]);
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'error_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'The disabled tool was not used.']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($agent->runStream('Try disabled tool', AgentOptions::withTools(['article_get'])));
+
+        $types = array_map(static fn (AgentEvent $e): string => $e->type, $events);
+        self::assertContains(AgentEvent::TOOL_RESULT, $types);
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        self::assertTrue($toolResultMessage->content[0]['is_error']);
+        self::assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
     }
 
     public function testMaxIterationsReached(): void
@@ -314,5 +404,34 @@ final class StreamingAgentTest extends TestCase
         self::assertCount(2, $this->agent->messages);
         self::assertSame('user', $this->agent->messages[0]->role);
         self::assertSame('assistant', $this->agent->messages[1]->role);
+    }
+
+    private function createStreamingAgentWithArticleAndErrorTools(FakeStreamingLlmClient $llmClient): StreamingAgent
+    {
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
+
+        return new StreamingAgent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: [
+                new Tool('article_get', 'Get an article', [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id'],
+                ]),
+                new Tool('error_get', 'Get error resource', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
     }
 }

--- a/tests/Runtime/ToolListTest.php
+++ b/tests/Runtime/ToolListTest.php
@@ -24,6 +24,7 @@ final class ToolListTest extends TestCase
         $toolList = new ToolList($tools);
 
         $this->assertTrue($toolList->isConfirmable('delete_user'));
+        $this->assertTrue($toolList->has('delete_user'));
     }
 
     public function testIsConfirmableReturnsFalseForNonConfirmableTool(): void
@@ -46,6 +47,7 @@ final class ToolListTest extends TestCase
         $toolList = new ToolList([]);
 
         $this->assertFalse($toolList->isConfirmable('unknown'));
+        $this->assertFalse($toolList->has('unknown'));
     }
 
     public function testMixedConfirmableTools(): void


### PR DESCRIPTION
## Summary

- Add per-call `AgentOptions` tool filtering for `Agent` and `StreamingAgent`.
- Add Input/Output Processor pipeline via `LlmRequest`, `InputProcessorInterface`, and `OutputProcessorInterface`.
- Add Agent-as-Tool support with `AgentProfile`, `AgentPool`, `AgentDelegator`, and `AgentFactory::addSubagents()`.
- Update README / README.ja examples and API tables.

Closes #15.
Closes #16.
Closes #17.

## Validation

- `zsh -ic 'sphp85; composer test'`
- `zsh -ic 'sphp85; composer cs'`
- `zsh -ic 'sphp85; composer sa'`
- `zsh -ic 'sphp85; composer tests'`

Note: `composer tests` still prints PHP 8.5 deprecation notices from PHPMD/PDepend dependencies, but exits successfully.