### PR TITLE
Add ALPS context processor

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -186,6 +186,23 @@ $response = $agent->run(
 
 `OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。
 
+`AlpsContextInputProcessor` を使うと、ALPS を runtime context として注入できます。現在の LLM 呼び出しで利用可能な tool に一致する `safe` / `unsafe` などの transition descriptor と、tool input に一致する semantic descriptor を追加します。
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+
+$alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
+
+$response = $agent->run(
+    'このユーザーを探して',
+    AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
 ### 7. Agent-as-Tool / Named Subagent
 
 専門エージェントを `AgentPool` に登録すると、`ask_{name}` という tool として公開できます。Subagent の会話履歴は呼び出しごとに隔離されます。
@@ -587,7 +604,7 @@ $dictionary = new AlpsSemanticDictionary('/path/to/profile.json');
 $converter = new SchemaConverter($dictionary);
 ```
 
-**JSON**と**XML**の両形式の ALPS プロファイルをサポートしています（ファイル拡張子で自動判別）。`semantic`記述子の`title`または`doc`がパラメータの説明として使用されます。同一プロファイル内の`href="#id"`参照は自動解決され、`safe` / `unsafe` / `idempotent`（トランジション）記述子は除外されます。
+**JSON**と**XML**の両形式の ALPS プロファイルをサポートしています（ファイル拡張子で自動判別）。`semantic`記述子の`title`または`doc`がパラメータの説明として使用されます。同一プロファイル内の`href="#id"`参照は自動解決されます。パラメータ説明では`safe` / `unsafe` / `idempotent`（トランジション）記述子は除外されますが、`AlpsContextInputProcessor` は一致する transition descriptor を runtime context として利用できます。
 
 ## パラメータ説明の優先順位
 
@@ -671,6 +688,7 @@ Dispatcherが検出するエラー:
 | `AgentFactory` | エージェントのビルダー（同期・ストリーミング） |
 | `AgentOptions` | ツール制限などの呼び出し単位オプション |
 | `LlmRequest` | Input Processor に渡される LLM request |
+| `AlpsContextInputProcessor` | 関連する ALPS descriptor を各 LLM request に追加 |
 | `AgentProfile` | Named Subagent の設定 |
 | `AgentPool` | Named Subagent の登録・作成 |
 | `AgentDelegator` | `ask_*` tool call を Subagent に委譲 |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ $response = $agent->run(
 
 `OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents.
 
+You can use ALPS as runtime context with `AlpsContextInputProcessor`. It injects matching tool descriptors such as `safe` or `unsafe` transitions, plus matching semantic descriptors for tool inputs.
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+
+$alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
+
+$response = $agent->run(
+    'Find this user',
+    AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
 ### 7. Agent-as-Tool / Named Subagents
 
 Register specialist agents in an `AgentPool`, then expose them as tools named `ask_{name}`. Subagent conversation history is isolated per call.
@@ -587,7 +604,7 @@ $dictionary = new AlpsSemanticDictionary('/path/to/profile.json');
 $converter = new SchemaConverter($dictionary);
 ```
 
-Both **JSON** and **XML** ALPS profiles are supported (format is detected from the file extension). The `title` or `doc` of `semantic` descriptors is used as the parameter description. Same-profile `href="#id"` references are resolved automatically; non-semantic descriptors (`safe` / `unsafe` / `idempotent`) are excluded.
+Both **JSON** and **XML** ALPS profiles are supported (format is detected from the file extension). The `title` or `doc` of `semantic` descriptors is used as the parameter description. Same-profile `href="#id"` references are resolved automatically. For parameter descriptions, non-semantic descriptors (`safe` / `unsafe` / `idempotent`) are excluded; `AlpsContextInputProcessor` can still use matching transition descriptors as runtime context.
 
 ## Parameter Description Priority
 
@@ -671,6 +688,7 @@ Errors detected by the Dispatcher:
 | `AgentFactory` | Builder for agents (sync and streaming) |
 | `AgentOptions` | Per-run options such as tool filtering |
 | `LlmRequest` | LLM request passed to input processors |
+| `AlpsContextInputProcessor` | Adds relevant ALPS descriptors to each LLM request |
 | `AgentProfile` | Configuration for a named subagent |
 | `AgentPool` | Registry and factory for named subagents |
 | `AgentDelegator` | Dispatches `ask_*` tool calls to subagents |

--- a/src/Runtime/AlpsContextInputProcessor.php
+++ b/src/Runtime/AlpsContextInputProcessor.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use Override;
+
+use function array_keys;
+use function implode;
+use function lcfirst;
+use function str_replace;
+use function ucwords;
+
+/**
+ * Adds ALPS semantic context for the tools available in an LLM call
+ */
+final readonly class AlpsContextInputProcessor implements InputProcessorInterface
+{
+    public function __construct(
+        private AlpsSemanticDictionary $dictionary,
+        private string $heading = 'Application semantics from ALPS:',
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $lines = $this->buildLines($request->tools);
+        if ($lines === []) {
+            return $request;
+        }
+
+        return $request->withMessages([
+            ...$request->messages,
+            Message::user($this->heading . "\n" . implode("\n", $lines)),
+        ]);
+    }
+
+    /**
+     * @param list<Tool> $tools
+     *
+     * @return list<string>
+     */
+    private function buildLines(array $tools): array
+    {
+        $lines = [];
+        $seen = [];
+        foreach ($tools as $tool) {
+            $this->addToolLine($tool, $lines, $seen);
+            $this->addParameterLines($tool, $lines, $seen);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param list<string>        $lines
+     * @param array<string, true> $seen
+     */
+    private function addToolLine(Tool $tool, array &$lines, array &$seen): void
+    {
+        $descriptor = $this->resolveDescriptor($tool->name);
+        if ($descriptor === null || $descriptor['description'] === null) {
+            return;
+        }
+
+        $key = $tool->name;
+        if ($descriptor['type'] !== 'semantic') {
+            $key .= ' [' . $descriptor['type'] . ']';
+        }
+
+        $this->addLine($key, $descriptor['description'], $lines, $seen);
+    }
+
+    /**
+     * @param list<string>        $lines
+     * @param array<string, true> $seen
+     */
+    private function addParameterLines(Tool $tool, array &$lines, array &$seen): void
+    {
+        foreach (array_keys($tool->inputSchema['properties']) as $paramName) {
+            $description = $this->resolveDescription($paramName);
+            if ($description === null) {
+                continue;
+            }
+
+            $this->addLine($tool->name . '.' . $paramName, $description, $lines, $seen);
+        }
+    }
+
+    private function resolveDescription(string $id): string|null
+    {
+        $description = $this->dictionary->get($id);
+        if ($description !== null) {
+            return $description;
+        }
+
+        return $this->dictionary->get($this->toCamelCase($id));
+    }
+
+    /** @return array{id: string, type: string, description: string|null, href: string|null}|null */
+    private function resolveDescriptor(string $id): array|null
+    {
+        $descriptor = $this->dictionary->getDescriptor($id);
+        if ($descriptor !== null) {
+            return $descriptor;
+        }
+
+        return $this->dictionary->getDescriptor($this->toCamelCase($id));
+    }
+
+    private function toCamelCase(string $id): string
+    {
+        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $id))));
+    }
+
+    /**
+     * @param list<string>        $lines
+     * @param array<string, true> $seen
+     */
+    private function addLine(string $key, string $description, array &$lines, array &$seen): void
+    {
+        if (isset($seen[$key])) {
+            return;
+        }
+
+        $lines[] = '- ' . $key . ': ' . $description;
+        $seen[$key] = true;
+    }
+}

--- a/src/Schema/AlpsDescriptorIndex.php
+++ b/src/Schema/AlpsDescriptorIndex.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Schema;
+
+use function str_starts_with;
+use function substr;
+
+/** @phpstan-type Entry array{id: string, type: string, description: string|null, href: string|null} */
+final class AlpsDescriptorIndex
+{
+    /** Maximum href chain depth (e.g. A -> B -> C). Guards against cycles. */
+    private const HREF_RESOLUTION_DEPTH = 10;
+
+    /** @var array<string, Entry> */
+    private array $descriptors;
+
+    /** @param list<Entry> $entries */
+    public function __construct(array $entries)
+    {
+        $this->descriptors = $this->buildDescriptorMap($entries);
+    }
+
+    /** @return Entry|null */
+    public function get(string $id): array|null
+    {
+        return $this->descriptors[$id] ?? null;
+    }
+
+    /** @return array<string, string> */
+    public function semanticDictionary(): array
+    {
+        $dictionary = [];
+        foreach ($this->descriptors as $entry) {
+            if ($entry['type'] !== 'semantic' || $entry['description'] === null) {
+                continue;
+            }
+
+            $dictionary[$entry['id']] = $entry['description'];
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * @param list<Entry> $entries
+     *
+     * @return array<string, Entry>
+     */
+    private function buildDescriptorMap(array $entries): array
+    {
+        $descriptors = [];
+        foreach ($entries as $entry) {
+            $descriptors[$entry['id']] = $entry;
+        }
+
+        for ($depth = 0; $depth < self::HREF_RESOLUTION_DEPTH; $depth++) {
+            if (! $this->resolveHrefPass($descriptors)) {
+                break;
+            }
+        }
+
+        return $descriptors;
+    }
+
+    /** @param array<string, Entry> $descriptors */
+    private function resolveHrefPass(array &$descriptors): bool
+    {
+        $changed = false;
+        foreach ($descriptors as $id => $entry) {
+            if ($entry['description'] !== null) {
+                continue;
+            }
+
+            $href = $entry['href'];
+            if ($href === null) {
+                continue;
+            }
+
+            if (! str_starts_with($href, '#')) {
+                continue;
+            }
+
+            $referencedId = substr($href, 1);
+            if (! isset($descriptors[$referencedId])) {
+                continue;
+            }
+
+            $referencedDescription = $descriptors[$referencedId]['description'];
+            if ($referencedDescription === null) {
+                continue;
+            }
+
+            $descriptors[$id]['description'] = $referencedDescription;
+            $changed = true;
+        }
+
+        return $changed;
+    }
+}

--- a/src/Schema/AlpsSemanticDictionary.php
+++ b/src/Schema/AlpsSemanticDictionary.php
@@ -22,9 +22,7 @@ use function libxml_use_internal_errors;
 use function pathinfo;
 use function simplexml_load_string;
 use function sprintf;
-use function str_starts_with;
 use function strtolower;
-use function substr;
 use function trim;
 
 use const JSON_THROW_ON_ERROR;
@@ -35,9 +33,10 @@ use const PATHINFO_EXTENSION;
  *
  * Parses an ALPS profile (JSON or XML) and exposes an
  * `id` => description mapping for semantic descriptors.
+ * Full descriptors, including transitions, are available through getDescriptor().
  *
  * Behavior matches koriym/app-state-diagram for the subset we need:
- *  - Only `type === 'semantic'` descriptors are included (transitions excluded).
+ *  - Only `type === 'semantic'` descriptors are included in the array mapping.
  *  - Same-profile `href="#id"` references resolve to the referenced description.
  *  - Cross-file href references are not supported.
  *
@@ -46,8 +45,7 @@ use const PATHINFO_EXTENSION;
  */
 final class AlpsSemanticDictionary extends ArrayObject
 {
-    /** Maximum href chain depth (e.g. A -> B -> C). Guards against cycles. */
-    private const HREF_RESOLUTION_DEPTH = 10;
+    private AlpsDescriptorIndex $descriptorIndex;
 
     public function __construct(string $profilePath)
     {
@@ -60,7 +58,9 @@ final class AlpsSemanticDictionary extends ArrayObject
             ),
         };
 
-        parent::__construct($this->buildDictionary($entries));
+        $this->descriptorIndex = new AlpsDescriptorIndex($entries);
+
+        parent::__construct($this->descriptorIndex->semanticDictionary());
     }
 
     public function get(string $key): string|null
@@ -68,71 +68,10 @@ final class AlpsSemanticDictionary extends ArrayObject
         return $this[$key] ?? null;
     }
 
-    /**
-     * @param list<Entry> $entries
-     *
-     * @return array<string, string>
-     */
-    private function buildDictionary(array $entries): array
+    /** @return Entry|null */
+    public function getDescriptor(string $id): array|null
     {
-        $semanticEntries = [];
-        foreach ($entries as $entry) {
-            if ($entry['type'] !== 'semantic') {
-                continue;
-            }
-
-            $semanticEntries[] = $entry;
-        }
-
-        $dictionary = [];
-        foreach ($semanticEntries as $entry) {
-            if ($entry['description'] === null) {
-                continue;
-            }
-
-            $dictionary[$entry['id']] = $entry['description'];
-        }
-
-        for ($depth = 0; $depth < self::HREF_RESOLUTION_DEPTH; $depth++) {
-            if (! $this->resolveHrefPass($semanticEntries, $dictionary)) {
-                break;
-            }
-        }
-
-        return $dictionary;
-    }
-
-    /**
-     * @param list<Entry>           $semanticEntries
-     * @param array<string, string> $dictionary
-     */
-    private function resolveHrefPass(array $semanticEntries, array &$dictionary): bool
-    {
-        $changed = false;
-        foreach ($semanticEntries as $entry) {
-            if (isset($dictionary[$entry['id']])) {
-                continue;
-            }
-
-            $href = $entry['href'];
-            if ($href === null) {
-                continue;
-            }
-
-            if (! str_starts_with($href, '#')) {
-                continue;
-            }
-
-            $referencedId = substr($href, 1);
-            if (! isset($dictionary[$referencedId])) {
-                continue;
-            }
-
-            $dictionary[$entry['id']] = $dictionary[$referencedId];
-            $changed = true;
-        }
-
-        return $changed;
+        return $this->descriptorIndex->get($id);
     }
 
     /** @return list<Entry> */

--- a/tests/Runtime/AlpsContextInputProcessorTest.php
+++ b/tests/Runtime/AlpsContextInputProcessorTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AlpsContextInputProcessor::class)]
+#[CoversClass(LlmRequest::class)]
+final class AlpsContextInputProcessorTest extends TestCase
+{
+    private AlpsSemanticDictionary $dictionary;
+
+    protected function setUp(): void
+    {
+        $this->dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
+    }
+
+    public function testAddsRelevantAlpsSemanticsForToolParameters(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Find the user')],
+            [
+                new Tool('user_get', 'Get user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'userId' => ['type' => 'integer'],
+                        'email' => ['type' => 'string'],
+                        'missing' => ['type' => 'string'],
+                    ],
+                    'required' => ['userId'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertNotSame($request, $processed);
+        $this->assertSame('system', $processed->systemPrompt);
+        $this->assertSame($request->tools, $processed->tools);
+        $this->assertCount(2, $processed->messages);
+        $this->assertSame(
+            "Application semantics from ALPS:\n- user_get.userId: User identifier",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testResolvesSnakeCaseParameterThroughCamelCaseAlpsId(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('user_post', 'Create user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'user_name' => ['type' => 'string'],
+                    ],
+                    'required' => ['user_name'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- user_post.user_name: Name of the user",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testAddsToolNameSemanticsWhenAvailable(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('userId', 'User identifier tool', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- userId: User identifier",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testAddsTransitionTypeForMatchingToolDescriptor(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('createUser', 'Create user', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- createUser [safe]: Create user transition",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testResolvesSnakeCaseToolThroughCamelCaseAlpsId(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('create_user', 'Create user', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- create_user [safe]: Create user transition",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testReturnsOriginalRequestWhenNoSemanticsMatch(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Call tool')],
+            [
+                new Tool('unknown_get', 'Unknown', [
+                    'type' => 'object',
+                    'properties' => [
+                        'unknown' => ['type' => 'string'],
+                    ],
+                    'required' => ['unknown'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame($request, $processed);
+    }
+
+    public function testCustomHeading(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary, 'ALPS context:');
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Find resource')],
+            [
+                new Tool('resource_get', 'Get resource', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "ALPS context:\n- resource_get.id: Resource identifier",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testDuplicateSemanticLinesAreCollapsed(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Find users')],
+            [
+                new Tool('user_get', 'Get user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+                new Tool('user_search', 'Search user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+                new Tool('user_get', 'Get user again', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n"
+            . "- user_get.id: Resource identifier\n"
+            . '- user_search.id: Resource identifier',
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+}

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(AlpsSemanticDictionary::class)]
+#[CoversClass(AlpsDescriptorIndex::class)]
 final class AlpsSemanticDictionaryTest extends TestCase
 {
     private AlpsSemanticDictionary $dictionary;
@@ -59,6 +60,21 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertNull($this->dictionary->get('createUser'));
     }
 
+    public function testGetDescriptorIncludesNonSemanticDescriptor(): void
+    {
+        $descriptor = $this->dictionary->getDescriptor('createUser');
+
+        $this->assertSame('createUser', $descriptor['id'] ?? null);
+        $this->assertSame('safe', $descriptor['type'] ?? null);
+        $this->assertSame('Create user transition', $descriptor['description'] ?? null);
+        $this->assertNull($descriptor['href'] ?? null);
+    }
+
+    public function testGetDescriptorForMissingId(): void
+    {
+        $this->assertNull($this->dictionary->getDescriptor('nonexistent'));
+    }
+
     public function testLocalHrefResolvesToReferencedDescription(): void
     {
         // userIdAlias has href="#userId" → resolves to "User identifier"
@@ -82,6 +98,10 @@ final class AlpsSemanticDictionaryTest extends TestCase
     {
         // href that does not start with '#' is not resolved (cross-file ref unsupported)
         $this->assertNull($this->dictionary->get('externalRef'));
+
+        $descriptor = $this->dictionary->getDescriptor('externalRef');
+        $this->assertSame('https://example.com/profile.json#userId', $descriptor['href'] ?? null);
+        $this->assertNull($descriptor['description'] ?? null);
     }
 
     public function testLoadXmlProfile(): void


### PR DESCRIPTION
## Summary

- Add `AlpsContextInputProcessor` to inject relevant ALPS context into each LLM request.
- Match tool descriptors, including ALPS transition types such as `safe` / `unsafe`, against available tool names.
- Match semantic descriptors against tool input parameter names, including snake_case to camelCase fallback.
- Split ALPS descriptor indexing from the semantic dictionary so `get()` remains semantic-only while `getDescriptor()` can expose transitions.
- Document runtime ALPS context usage in README / README.ja.

This is stacked on #18 because it uses the new processor pipeline.

## Validation

- `zsh -ic 'sphp85; vendor/bin/phpunit tests/Schema/AlpsSemanticDictionaryTest.php tests/Runtime/AlpsContextInputProcessorTest.php'`\n- `zsh -ic 'sphp85; composer cs'`\n- `zsh -ic 'sphp85; composer sa'`\n- `zsh -ic 'sphp85; composer phpmd'`\n- `zsh -ic 'sphp85; composer tests'`\n- `zsh -ic 'sphp85; XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text'`\n\nCoverage: 100% classes / methods / lines.\n\nNote: PHP 8.5 still prints deprecation notices from PHPMD/PDepend dependencies, but the validation commands exit successfully.