### PR TITLE
Add ALPS tool policy processor

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -191,6 +191,7 @@ $response = $agent->run(
 ```php
 use BEAR\ToolUse\Runtime\AgentOptions;
 use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Runtime\AlpsToolPolicyInputProcessor;
 use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
 
 $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
@@ -198,6 +199,18 @@ $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
 $response = $agent->run(
     'このユーザーを探して',
     AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
+ALPS の transition type を呼び出し単位の tool policy として使うこともできます。`safeOnly()` policy は、一致する ALPS descriptor が `safe` または `idempotent` の tool だけを公開します。一致する descriptor がない tool は、`safeOnlyAllowingUnknownTools()` を使わない限り隠されます。
+
+```php
+$response = $agent->run(
+    '現在のアカウント状態を変更せずに要約して',
+    AgentOptions::withProcessors(inputProcessors: [
+        AlpsToolPolicyInputProcessor::safeOnly($alps),
         new AlpsContextInputProcessor($alps),
     ]),
 );
@@ -689,6 +702,7 @@ Dispatcherが検出するエラー:
 | `AgentOptions` | ツール制限などの呼び出し単位オプション |
 | `LlmRequest` | Input Processor に渡される LLM request |
 | `AlpsContextInputProcessor` | 関連する ALPS descriptor を各 LLM request に追加 |
+| `AlpsToolPolicyInputProcessor` | ALPS transition type に一致する tool だけに絞り込み |
 | `AgentProfile` | Named Subagent の設定 |
 | `AgentPool` | Named Subagent の登録・作成 |
 | `AgentDelegator` | `ask_*` tool call を Subagent に委譲 |

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ You can use ALPS as runtime context with `AlpsContextInputProcessor`. It injects
 ```php
 use BEAR\ToolUse\Runtime\AgentOptions;
 use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Runtime\AlpsToolPolicyInputProcessor;
 use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
 
 $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
@@ -198,6 +199,18 @@ $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
 $response = $agent->run(
     'Find this user',
     AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
+You can also use ALPS transition types as a per-call tool policy. The `safeOnly()` policy exposes only tools whose matching ALPS descriptor is `safe` or `idempotent`; tools without a matching descriptor are hidden unless you use `safeOnlyAllowingUnknownTools()`.
+
+```php
+$response = $agent->run(
+    'Summarize the current account state without changing it',
+    AgentOptions::withProcessors(inputProcessors: [
+        AlpsToolPolicyInputProcessor::safeOnly($alps),
         new AlpsContextInputProcessor($alps),
     ]),
 );
@@ -689,6 +702,7 @@ Errors detected by the Dispatcher:
 | `AgentOptions` | Per-run options such as tool filtering |
 | `LlmRequest` | LLM request passed to input processors |
 | `AlpsContextInputProcessor` | Adds relevant ALPS descriptors to each LLM request |
+| `AlpsToolPolicyInputProcessor` | Filters tools by matching ALPS transition types |
 | `AgentProfile` | Configuration for a named subagent |
 | `AgentPool` | Registry and factory for named subagents |
 | `AgentDelegator` | Dispatches `ask_*` tool calls to subagents |

--- a/src/Runtime/AlpsToolPolicyInputProcessor.php
+++ b/src/Runtime/AlpsToolPolicyInputProcessor.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use Override;
+
+use function in_array;
+use function lcfirst;
+use function str_replace;
+use function ucwords;
+
+/** Filters available tools by matching ALPS descriptor types */
+final readonly class AlpsToolPolicyInputProcessor implements InputProcessorInterface
+{
+    public const UNKNOWN_TOOLS_HIDDEN = 'hidden';
+    public const UNKNOWN_TOOLS_ALLOWED = 'allowed';
+
+    /**
+     * @param list<string>                                           $allowedTypes
+     * @param self::UNKNOWN_TOOLS_HIDDEN|self::UNKNOWN_TOOLS_ALLOWED $unknownToolPolicy
+     */
+    public function __construct(
+        private AlpsSemanticDictionary $dictionary,
+        private array $allowedTypes,
+        private string $unknownToolPolicy = self::UNKNOWN_TOOLS_HIDDEN,
+    ) {
+    }
+
+    public static function safeOnly(AlpsSemanticDictionary $dictionary): self
+    {
+        return new self($dictionary, ['safe', 'idempotent']);
+    }
+
+    public static function safeOnlyAllowingUnknownTools(AlpsSemanticDictionary $dictionary): self
+    {
+        return new self($dictionary, ['safe', 'idempotent'], self::UNKNOWN_TOOLS_ALLOWED);
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $tools = [];
+        foreach ($request->tools as $tool) {
+            if (! $this->allows($tool)) {
+                continue;
+            }
+
+            $tools[] = $tool;
+        }
+
+        if ($tools === $request->tools) {
+            return $request;
+        }
+
+        return $request->withTools($tools);
+    }
+
+    private function allows(Tool $tool): bool
+    {
+        $descriptor = $this->resolveDescriptor($tool->name);
+        if ($descriptor === null) {
+            return $this->unknownToolPolicy === self::UNKNOWN_TOOLS_ALLOWED;
+        }
+
+        return in_array($descriptor['type'], $this->allowedTypes, true);
+    }
+
+    /** @return array{id: string, type: string, description: string|null, href: string|null}|null */
+    private function resolveDescriptor(string $id): array|null
+    {
+        $descriptor = $this->dictionary->getDescriptor($id);
+        if ($descriptor !== null) {
+            return $descriptor;
+        }
+
+        return $this->dictionary->getDescriptor($this->toCamelCase($id));
+    }
+
+    private function toCamelCase(string $id): string
+    {
+        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $id))));
+    }
+}

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -41,6 +41,16 @@
         "title": "Create user transition"
       },
       {
+        "id": "syncUser",
+        "type": "idempotent",
+        "title": "Synchronize user transition"
+      },
+      {
+        "id": "deleteUser",
+        "type": "unsafe",
+        "title": "Delete user transition"
+      },
+      {
         "id": "userIdAlias",
         "type": "semantic",
         "href": "#userId"

--- a/tests/Fake/alps-profile.xml
+++ b/tests/Fake/alps-profile.xml
@@ -12,6 +12,8 @@
     </descriptor>
   </descriptor>
   <descriptor id="createUser" type="safe" title="Create user transition"/>
+  <descriptor id="syncUser" type="idempotent" title="Synchronize user transition"/>
+  <descriptor id="deleteUser" type="unsafe" title="Delete user transition"/>
   <descriptor id="userIdAlias" type="semantic" href="#userId"/>
   <descriptor id="danglingHref" type="semantic" href="#nonExistent"/>
   <descriptor id="chainA" type="semantic" href="#chainB"/>

--- a/tests/Runtime/AlpsToolPolicyInputProcessorTest.php
+++ b/tests/Runtime/AlpsToolPolicyInputProcessorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AlpsToolPolicyInputProcessor::class)]
+#[CoversClass(LlmRequest::class)]
+final class AlpsToolPolicyInputProcessorTest extends TestCase
+{
+    private AlpsSemanticDictionary $dictionary;
+
+    protected function setUp(): void
+    {
+        $this->dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
+    }
+
+    public function testSafeOnlyKeepsSafeAndIdempotentTools(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('syncUser'),
+            $this->tool('deleteUser'),
+            $this->tool('unknownTool'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertNotSame($request, $processed);
+        $this->assertSame(
+            ['createUser', 'syncUser'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testSafeOnlyCanAllowUnknownTools(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnlyAllowingUnknownTools($this->dictionary);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('deleteUser'),
+            $this->tool('unknownTool'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['createUser', 'unknownTool'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testCustomAllowedTypes(): void
+    {
+        $processor = new AlpsToolPolicyInputProcessor($this->dictionary, ['unsafe']);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('deleteUser'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['deleteUser'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testResolvesSnakeCaseToolThroughCamelCaseAlpsId(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
+        $request = $this->request([
+            $this->tool('create_user'),
+            $this->tool('delete_user'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['create_user'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testReturnsOriginalRequestWhenNoToolIsFiltered(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('syncUser'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame($request, $processed);
+    }
+
+    /** @param list<Tool> $tools */
+    private function request(array $tools): LlmRequest
+    {
+        return new LlmRequest('system', [Message::user('Run tools')], $tools);
+    }
+
+    private function tool(string $name): Tool
+    {
+        return new Tool($name, 'Tool ' . $name, [
+            'type' => 'object',
+            'properties' => [],
+            'required' => [],
+        ]);
+    }
+
+    /** @return list<string> */
+    private function toolNames(LlmRequest $request): array
+    {
+        $names = [];
+        foreach ($request->tools as $tool) {
+            $names[] = $tool->name;
+        }
+
+        return $names;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AlpsToolPolicyInputProcessor` to filter available tools by matching ALPS descriptor types.
- Provide a `safeOnly()` policy that exposes `safe` and `idempotent` transitions while hiding unknown or unsafe tools by default.
- Add an explicit `safeOnlyAllowingUnknownTools()` factory for permissive mode without a boolean flag argument.
- Document ALPS-driven per-call tool policy usage in README / README.ja.

This is stacked on #19 because it uses ALPS descriptor indexing and the input processor pipeline.

## Validation

- `zsh -ic 'sphp85; vendor/bin/phpunit tests/Runtime/AlpsToolPolicyInputProcessorTest.php tests/Runtime/AlpsContextInputProcessorTest.php tests/Schema/AlpsSemanticDictionaryTest.php'`
- `zsh -ic 'sphp85; composer cs'`
- `zsh -ic 'sphp85; composer sa'`
- `zsh -ic 'sphp85; composer phpmd'`
- `zsh -ic 'sphp85; composer tests'`
- `zsh -ic 'sphp85; XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text'`

Coverage: 100% classes / methods / lines.

Note: PHP 8.5 still prints deprecation notices from PHPMD/PDepend dependencies, but the validation commands exit successfully.