### PR TITLE
Preserve assistant responses in agent history

### DIFF
--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -61,7 +61,9 @@ final class Agent implements AgentInterface
 
             switch ($response->stopReason) {
                 case 'end_turn':
-                    return AgentResponse::completed($response->content);
+                    $this->recordAssistantResponse($response);
+
+                    return AgentResponse::completed($response->content, $this->messages);
 
                 case 'tool_use':
                     $this->messages[] = Message::assistant($response->content);
@@ -70,16 +72,20 @@ final class Agent implements AgentInterface
                     break;
 
                 case 'max_tokens':
-                    $this->messages[] = Message::assistant($response->content);
+                    $this->recordAssistantResponse($response);
 
                     return AgentResponse::maxTokensReached($response->content, $this->messages);
 
                 case 'stop_sequence':
+                    $this->recordAssistantResponse($response);
+
                     return AgentResponse::stopSequenceReached($response->content, $this->messages);
 
                 default:
                     // Unknown stop reason - treat as completed
-                    return AgentResponse::completed($response->content);
+                    $this->recordAssistantResponse($response);
+
+                    return AgentResponse::completed($response->content, $this->messages);
             }
         }
 
@@ -148,5 +154,14 @@ final class Agent implements AgentInterface
     {
         return $this->confirmationHandler !== null
             && $toolList->isConfirmable($toolCall->name);
+    }
+
+    private function recordAssistantResponse(LlmResponse $response): void
+    {
+        if ($response->content === []) {
+            return;
+        }
+
+        $this->messages[] = Message::assistant($response->content);
     }
 }

--- a/src/Runtime/AgentResponse.php
+++ b/src/Runtime/AgentResponse.php
@@ -27,9 +27,10 @@ final readonly class AgentResponse
     ) {
     }
 
-    public static function completed(mixed $content): self
+    /** @param list<Message> $messages */
+    public static function completed(mixed $content, array $messages = []): self
     {
-        return new self(true, self::STOP_COMPLETED, $content, []);
+        return new self(true, self::STOP_COMPLETED, $content, $messages);
     }
 
     /** @param list<Message> $messages */

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -109,6 +109,8 @@ final class StreamingAgent implements StreamingAgentInterface
             }
 
             // Other stop reasons (max_tokens, stop_sequence) - complete
+            $this->recordContentBlocks($state);
+
             yield AgentEvent::completed($fullText);
 
             return;

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -64,6 +64,10 @@ final class AgentTest extends TestCase
 
         $this->assertTrue($response->completed);
         $this->assertSame('Hello! How can I help you?', $response->getText());
+        $this->assertCount(2, $this->agent->messages);
+        $this->assertSame('user', $this->agent->messages[0]->role);
+        $this->assertSame('assistant', $this->agent->messages[1]->role);
+        $this->assertSame($this->agent->messages, $response->messages);
     }
 
     public function testMaxIterationsReached(): void
@@ -89,6 +93,8 @@ final class AgentTest extends TestCase
         $this->assertFalse($response->completed);
         $this->assertSame(AgentResponse::STOP_MAX_TOKENS, $response->stopReason);
         $this->assertSame('This response was cut off...', $response->getText());
+        $this->assertCount(2, $response->messages);
+        $this->assertSame('assistant', $response->messages[1]->role);
     }
 
     public function testStopSequenceResponse(): void
@@ -99,6 +105,8 @@ final class AgentTest extends TestCase
 
         $this->assertFalse($response->completed);
         $this->assertSame(AgentResponse::STOP_STOP_SEQUENCE, $response->stopReason);
+        $this->assertCount(2, $response->messages);
+        $this->assertSame('assistant', $response->messages[1]->role);
     }
 
     public function testUnknownStopReasonTreatedAsCompleted(): void
@@ -112,6 +120,24 @@ final class AgentTest extends TestCase
         $response = $this->agent->run('Test unknown stop reason');
 
         $this->assertTrue($response->completed);
+        $this->assertCount(2, $response->messages);
+        $this->assertSame('assistant', $response->messages[1]->role);
+    }
+
+    public function testEmptyAssistantResponseIsNotRecorded(): void
+    {
+        $this->llmClient->queueResponse(new LlmResponse(
+            stopReason: 'end_turn',
+            content: [],
+            toolCalls: [],
+        ));
+
+        $response = $this->agent->run('Return nothing');
+
+        $this->assertTrue($response->completed);
+        $this->assertCount(1, $this->agent->messages);
+        $this->assertSame('user', $this->agent->messages[0]->role);
+        $this->assertSame($this->agent->messages, $response->messages);
     }
 
     public function testToolUseWithSuccessfulDispatch(): void
@@ -267,7 +293,7 @@ final class AgentTest extends TestCase
         $response = $this->agent->run('Follow up question');
 
         $this->assertTrue($response->completed);
-        $this->assertCount(3, $this->agent->messages); // 2 history + 1 new user
+        $this->assertCount(4, $this->agent->messages); // 2 history + new user + assistant response
     }
 
     public function testAgentResponseCompleted(): void
@@ -277,6 +303,18 @@ final class AgentTest extends TestCase
         $this->assertTrue($response->completed);
         $this->assertSame('Done', $response->getText());
         $this->assertEmpty($response->messages);
+    }
+
+    public function testAgentResponseCompletedWithMessages(): void
+    {
+        $messages = [
+            Message::user('test'),
+            Message::assistant([['type' => 'text', 'text' => 'Done']]),
+        ];
+        $response = AgentResponse::completed([['type' => 'text', 'text' => 'Done']], $messages);
+
+        $this->assertTrue($response->completed);
+        $this->assertSame($messages, $response->messages);
     }
 
     public function testAgentResponseMaxIterations(): void

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -294,6 +294,9 @@ final class StreamingAgentTest extends TestCase
         $lastEvent = end($events);
         self::assertSame(AgentEvent::COMPLETED, $lastEvent->type);
         self::assertSame('Partial', $lastEvent->data['fullText']);
+        self::assertCount(2, $this->agent->messages);
+        self::assertSame('assistant', $this->agent->messages[1]->role);
+        self::assertSame('Partial', $this->agent->messages[1]->content[0]['text']);
     }
 
     public function testToolDispatchException(): void


### PR DESCRIPTION
## Summary

- Record final assistant responses in non-streaming `Agent` conversation history.
- Return the final message history from completed `AgentResponse` objects while keeping `AgentResponse::completed($content)` backward-compatible.
- Preserve partial streaming assistant output for non-`end_turn` stop reasons such as `max_tokens`.
- Add regression coverage for completed, partial, stop-sequence, unknown-stop, and empty assistant responses.

This is stacked on #20 because it builds on the current agent runtime branch.

## Validation

- `zsh -ic 'sphp85; vendor/bin/phpunit tests/Runtime/AgentTest.php tests/Runtime/StreamingAgentTest.php'`
- `zsh -ic 'sphp85; composer cs'`
- `zsh -ic 'sphp85; composer sa'`
- `zsh -ic 'sphp85; composer phpmd'`
- `zsh -ic 'sphp85; composer tests'`
- `zsh -ic 'sphp85; XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text'`

Coverage: 100% classes / methods / lines.

Note: PHP 8.5 still prints deprecation notices from PHPMD/PDepend dependencies, but the validation commands exit successfully.