### PR TITLE
Preview: Semantic Hypermedia Agent Runtime integration

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -204,7 +204,7 @@ $response = $agent->run(
 );
 ```
 
-ALPS の transition type を呼び出し単位の tool policy として使うこともできます。`safeOnly()` policy は、一致する ALPS descriptor が `safe` または `idempotent` の tool だけを公開します。一致する descriptor がない tool は、`safeOnlyAllowingUnknownTools()` を使わない限り隠されます。
+ALPS の transition type を呼び出し単位の tool policy として使うこともできます。`safeOnly()` policy は、一致する ALPS descriptor が `safe` の tool だけを公開します。一致する descriptor がない tool は、`safeOnlyAllowingUnknownTools()` を使わない限り隠されます。冪等だが状態変更を伴う transition も許可する場合は `safeAndIdempotent()` を使います。policy と context processor を組み合わせる場合は、policy を先に置くことで `AlpsContextInputProcessor` がフィルタ後に残った tool だけを説明できます。
 
 ```php
 $response = $agent->run(
@@ -251,6 +251,8 @@ Subagent は直接呼び出すこともできます。
 ```php
 $response = $delegator->ask('critic', 'この設計のリスクは？', ['articleId' => 1]);
 ```
+
+`AgentPool` が作成する Subagent は、pool に `ConfirmationHandlerInterface` が設定されていない場合、確認対象 tool をデフォルトで拒否します。Subagent に `#[Tool(confirm: true)]` の resource 実行を許可したい場合は、`AgentPool` に confirmation handler を渡してください。
 
 ### 8. 会話履歴
 
@@ -425,7 +427,7 @@ Y → ツール実行
 N → "User cancelled this operation." → LLM: 「承知しました。」
 ```
 
-`ConfirmationHandlerInterface` がバインドされていない場合、確認対象ツールも通常通り実行されます（ブロックなし）。
+直接作成した `Agent` では、`ConfirmationHandlerInterface` がバインドされていない場合、確認対象ツールも通常通り実行されます（ブロックなし）。一方、`AgentPool` が作成する Subagent はより保守的で、pool に confirmation handler がない場合、確認対象の Subagent tool call はデフォルトでキャンセルされます。
 
 ### ストリーミングエージェントでの確認
 
@@ -685,7 +687,9 @@ Dispatcherが検出するエラー:
 | `SchemaConverterInterface` | リソースからツール定義への変換 |
 | `ToolCollectorInterface` | ツールの収集と登録 |
 | `AgentInterface` | エージェントランタイム |
+| `OptionAwareAgentInterface` | 呼び出し単位の `AgentOptions` に対応したエージェントランタイム |
 | `StreamingAgentInterface` | ストリーミングエージェントランタイム |
+| `OptionAwareStreamingAgentInterface` | 呼び出し単位の `AgentOptions` に対応したストリーミングエージェントランタイム |
 | `ToolResultFilterInterface` | LLM送信前のレスポンスフィルタ |
 | `InputProcessorInterface` | LLM 呼び出し前に request を処理 |
 | `OutputProcessorInterface` | LLM 呼び出し後に response または stream event を処理 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -134,7 +134,95 @@ if ($response->completed) {
 }
 ```
 
-### 5. 会話履歴
+### 5. 呼び出し単位のツール制限
+
+`AgentOptions` を使うと、1回の `run()` で利用できるツールを制限できます。収集済みの Resource registry は変更せず、その呼び出しで LLM に渡す tool list だけを絞ります。
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+
+$response = $agent->run(
+    '記事を検索してください。変更はしないでください。',
+    AgentOptions::withTools(['article_get', 'search_get']),
+);
+```
+
+存在しない tool 名を指定した場合は、LLM 呼び出し前に例外になります。typo や policy 設定ミスを早期に検出できます。
+
+Streaming Agent でも同じ option を使えます。
+
+```php
+foreach ($agent->runStream('記事を検索して', AgentOptions::withTools(['search_get'])) as $event) {
+    // ...
+}
+```
+
+### 6. Input/Output Processor
+
+Processor を使うと、Agent runtime を肥大化させずに各 LLM 呼び出しを拡張できます。Input Processor は LLM 呼び出し前に system prompt、messages、tools を加工できます。Output Processor は LLM 呼び出し後の response を検査・正規化できます。tool result 後の再問い合わせを含め、各 iteration で毎回適用されます。
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\Message;
+
+final class MemoryProcessor implements InputProcessorInterface
+{
+    public function process(LlmRequest $request): LlmRequest
+    {
+        return $request->withMessages([
+            ...$request->messages,
+            Message::user('既知の文脈: ユーザーは簡潔な回答を好む。'),
+        ]);
+    }
+}
+
+$response = $agent->run(
+    'この記事を要約して',
+    AgentOptions::withProcessors(inputProcessors: [new MemoryProcessor()]),
+);
+```
+
+`OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。
+
+### 7. Agent-as-Tool / Named Subagent
+
+専門エージェントを `AgentPool` に登録すると、`ask_{name}` という tool として公開できます。Subagent の会話履歴は呼び出しごとに隔離されます。
+
+```php
+use BEAR\ToolUse\Runtime\AgentDelegator;
+use BEAR\ToolUse\Runtime\AgentFactory;
+use BEAR\ToolUse\Runtime\AgentPool;
+use BEAR\ToolUse\Runtime\AgentProfile;
+
+$pool = new AgentPool($llmClient, $resourceDispatcher, $collector);
+$pool->register(new AgentProfile(
+    name: 'critic',
+    description: '設計上のリスクをレビューする',
+    systemPrompt: 'You are a critical reviewer.',
+    resources: ['app://self/article'],
+));
+
+$delegator = new AgentDelegator($pool, $resourceDispatcher);
+$factory = new AgentFactory($llmClient, $delegator, $collector, $registry);
+
+$agent = $factory
+    ->addResources(['app://self/article'])
+    ->addSubagents($pool)
+    ->create('あなたは調整役のエージェントです。');
+
+// LLM が ask_critic を呼ぶと、AgentDelegator が critic agent を実行し、
+// 結果を通常の tool_result として LLM に返します。
+```
+
+Subagent は直接呼び出すこともできます。
+
+```php
+$response = $delegator->ask('critic', 'この設計のリスクは？', ['articleId' => 1]);
+```
+
+### 8. 会話履歴
 
 エージェントは複数の `run()` 呼び出しにわたって会話履歴を保持します。
 
@@ -156,7 +244,7 @@ $response = $agent->run('このユーザーについてもっと教えて');
 $agent->reset();
 ```
 
-### 6. ストリーミングエージェント
+### 9. ストリーミングエージェント
 
 リアルタイム出力（SSE、WebSocket）には、ストリーミングエージェントを使用します。LLMの出力に応じてイベントをyieldします。
 
@@ -569,6 +657,8 @@ Dispatcherが検出するエラー:
 | `AgentInterface` | エージェントランタイム |
 | `StreamingAgentInterface` | ストリーミングエージェントランタイム |
 | `ToolResultFilterInterface` | LLM送信前のレスポンスフィルタ |
+| `InputProcessorInterface` | LLM 呼び出し前に request を処理 |
+| `OutputProcessorInterface` | LLM 呼び出し後に response または stream event を処理 |
 | `ConfirmationHandlerInterface` | 破壊的ツールのユーザー確認 |
 | `ToolCallObserverInterface` | ディスパッチごとに 1 回呼ばれるフック（監査・メトリクス・レイテンシ計測） |
 
@@ -579,6 +669,11 @@ Dispatcherが検出するエラー:
 | `Agent` | LLMとの会話ループを管理 |
 | `StreamingAgent` | `AgentEvent`をyieldするストリーミング会話ループ |
 | `AgentFactory` | エージェントのビルダー（同期・ストリーミング） |
+| `AgentOptions` | ツール制限などの呼び出し単位オプション |
+| `LlmRequest` | Input Processor に渡される LLM request |
+| `AgentProfile` | Named Subagent の設定 |
+| `AgentPool` | Named Subagent の登録・作成 |
+| `AgentDelegator` | `ask_*` tool call を Subagent に委譲 |
 | `AgentResponse` | エージェント実行結果（同期） |
 | `AgentEvent` | ストリーミングイベント（`JsonSerializable`） |
 | `StreamEvent` | 低レベルLLMストリームイベント |

--- a/README.ja.md
+++ b/README.ja.md
@@ -184,9 +184,9 @@ $response = $agent->run(
 );
 ```
 
-`OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。
+`OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。受け取ったものと同じ具体型を返す必要があります。text content は書き換えられますが、runtime が tool call を安全に dispatch できるように tool-use の制御データは保持してください。
 
-`AlpsContextInputProcessor` を使うと、ALPS を runtime context として注入できます。現在の LLM 呼び出しで利用可能な tool に一致する `safe` / `unsafe` などの transition descriptor と、tool input に一致する semantic descriptor を追加します。
+`AlpsContextInputProcessor` を使うと、ALPS を runtime context として注入できます。現在の LLM 呼び出しで利用可能な tool に一致する `safe` / `unsafe` などの transition descriptor と、tool input に一致する semantic descriptor を追加します。tool descriptor は tool 名（または camelCase 形）で照合されるため、`article_get` tool には `article_get` または `articleGet` のような ALPS descriptor id が必要です。tool input parameter は semantic descriptor のみを参照します。
 
 ```php
 use BEAR\ToolUse\Runtime\AgentOptions;
@@ -204,7 +204,7 @@ $response = $agent->run(
 );
 ```
 
-ALPS の transition type を呼び出し単位の tool policy として使うこともできます。`safeOnly()` policy は、一致する ALPS descriptor が `safe` の tool だけを公開します。一致する descriptor がない tool は、`safeOnlyAllowingUnknownTools()` を使わない限り隠されます。冪等だが状態変更を伴う transition も許可する場合は `safeAndIdempotent()` を使います。policy と context processor を組み合わせる場合は、policy を先に置くことで `AlpsContextInputProcessor` がフィルタ後に残った tool だけを説明できます。
+ALPS の transition type を呼び出し単位の tool policy として使うこともできます。`safeOnly()` policy は、一致する ALPS descriptor が `safe` の tool だけを公開します。一致する descriptor がない tool は、`safeOnlyAllowingUnknownTools()` を使わない限り隠されます。冪等だが状態変更を伴う transition も許可する場合は `safeAndIdempotent()` を使います。この policy は、期待する tool が ALPS profile で網羅されている状態で使うか、移行中は unknown 許可 variant を選んでください。policy と context processor を組み合わせる場合は、policy を先に置くことで `AlpsContextInputProcessor` がフィルタ後に残った tool だけを説明できます。
 
 ```php
 $response = $agent->run(
@@ -275,6 +275,8 @@ $response = $agent->run('このユーザーについてもっと教えて');
 // 履歴をクリアして新しい会話を開始
 $agent->reset();
 ```
+
+`AgentResponse::$messages` は、`Agent::run()` から返された場合は停止時点の会話履歴スナップショットです。`AgentResponse::completed($content)` などの factory を直接呼ぶ場合は、明示的に渡さない限り履歴は空です。
 
 ### 9. ストリーミングエージェント
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -186,6 +186,23 @@ $response = $agent->run(
 
 `OutputProcessorInterface` は通常の Agent では `LlmResponse`、Streaming Agent では `StreamEvent` を受け取ります。
 
+`AlpsContextInputProcessor` を使うと、ALPS を runtime context として注入できます。現在の LLM 呼び出しで利用可能な tool に一致する `safe` / `unsafe` などの transition descriptor と、tool input に一致する semantic descriptor を追加します。
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+
+$alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
+
+$response = $agent->run(
+    'このユーザーを探して',
+    AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
 ### 7. Agent-as-Tool / Named Subagent
 
 専門エージェントを `AgentPool` に登録すると、`ask_{name}` という tool として公開できます。Subagent の会話履歴は呼び出しごとに隔離されます。
@@ -587,7 +604,7 @@ $dictionary = new AlpsSemanticDictionary('/path/to/profile.json');
 $converter = new SchemaConverter($dictionary);
 ```
 
-**JSON**と**XML**の両形式の ALPS プロファイルをサポートしています（ファイル拡張子で自動判別）。`semantic`記述子の`title`または`doc`がパラメータの説明として使用されます。同一プロファイル内の`href="#id"`参照は自動解決され、`safe` / `unsafe` / `idempotent`（トランジション）記述子は除外されます。
+**JSON**と**XML**の両形式の ALPS プロファイルをサポートしています（ファイル拡張子で自動判別）。`semantic`記述子の`title`または`doc`がパラメータの説明として使用されます。同一プロファイル内の`href="#id"`参照は自動解決されます。パラメータ説明では`safe` / `unsafe` / `idempotent`（トランジション）記述子は除外されますが、`AlpsContextInputProcessor` は一致する transition descriptor を runtime context として利用できます。
 
 ## パラメータ説明の優先順位
 
@@ -671,6 +688,7 @@ Dispatcherが検出するエラー:
 | `AgentFactory` | エージェントのビルダー（同期・ストリーミング） |
 | `AgentOptions` | ツール制限などの呼び出し単位オプション |
 | `LlmRequest` | Input Processor に渡される LLM request |
+| `AlpsContextInputProcessor` | 関連する ALPS descriptor を各 LLM request に追加 |
 | `AgentProfile` | Named Subagent の設定 |
 | `AgentPool` | Named Subagent の登録・作成 |
 | `AgentDelegator` | `ask_*` tool call を Subagent に委譲 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -191,6 +191,7 @@ $response = $agent->run(
 ```php
 use BEAR\ToolUse\Runtime\AgentOptions;
 use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Runtime\AlpsToolPolicyInputProcessor;
 use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
 
 $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
@@ -198,6 +199,18 @@ $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
 $response = $agent->run(
     'このユーザーを探して',
     AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
+ALPS の transition type を呼び出し単位の tool policy として使うこともできます。`safeOnly()` policy は、一致する ALPS descriptor が `safe` または `idempotent` の tool だけを公開します。一致する descriptor がない tool は、`safeOnlyAllowingUnknownTools()` を使わない限り隠されます。
+
+```php
+$response = $agent->run(
+    '現在のアカウント状態を変更せずに要約して',
+    AgentOptions::withProcessors(inputProcessors: [
+        AlpsToolPolicyInputProcessor::safeOnly($alps),
         new AlpsContextInputProcessor($alps),
     ]),
 );
@@ -689,6 +702,7 @@ Dispatcherが検出するエラー:
 | `AgentOptions` | ツール制限などの呼び出し単位オプション |
 | `LlmRequest` | Input Processor に渡される LLM request |
 | `AlpsContextInputProcessor` | 関連する ALPS descriptor を各 LLM request に追加 |
+| `AlpsToolPolicyInputProcessor` | ALPS transition type に一致する tool だけに絞り込み |
 | `AgentProfile` | Named Subagent の設定 |
 | `AgentPool` | Named Subagent の登録・作成 |
 | `AgentDelegator` | `ask_*` tool call を Subagent に委譲 |

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ You can use ALPS as runtime context with `AlpsContextInputProcessor`. It injects
 ```php
 use BEAR\ToolUse\Runtime\AgentOptions;
 use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Runtime\AlpsToolPolicyInputProcessor;
 use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
 
 $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
@@ -198,6 +199,18 @@ $alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
 $response = $agent->run(
     'Find this user',
     AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
+You can also use ALPS transition types as a per-call tool policy. The `safeOnly()` policy exposes only tools whose matching ALPS descriptor is `safe` or `idempotent`; tools without a matching descriptor are hidden unless you use `safeOnlyAllowingUnknownTools()`.
+
+```php
+$response = $agent->run(
+    'Summarize the current account state without changing it',
+    AgentOptions::withProcessors(inputProcessors: [
+        AlpsToolPolicyInputProcessor::safeOnly($alps),
         new AlpsContextInputProcessor($alps),
     ]),
 );
@@ -689,6 +702,7 @@ Errors detected by the Dispatcher:
 | `AgentOptions` | Per-run options such as tool filtering |
 | `LlmRequest` | LLM request passed to input processors |
 | `AlpsContextInputProcessor` | Adds relevant ALPS descriptors to each LLM request |
+| `AlpsToolPolicyInputProcessor` | Filters tools by matching ALPS transition types |
 | `AgentProfile` | Configuration for a named subagent |
 | `AgentPool` | Registry and factory for named subagents |
 | `AgentDelegator` | Dispatches `ask_*` tool calls to subagents |

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ $response = $agent->run(
 );
 ```
 
-`OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents.
+`OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents. It must return the same concrete type it receives. Text content may be rewritten, but tool-use control data must be preserved so the runtime can dispatch tool calls safely.
 
-You can use ALPS as runtime context with `AlpsContextInputProcessor`. It injects matching tool descriptors such as `safe` or `unsafe` transitions, plus matching semantic descriptors for tool inputs.
+You can use ALPS as runtime context with `AlpsContextInputProcessor`. It injects matching tool descriptors such as `safe` or `unsafe` transitions, plus matching semantic descriptors for tool inputs. Tool descriptors match by tool name (or its camelCase form), so an `article_get` tool needs an ALPS descriptor id such as `article_get` or `articleGet`. Tool input parameters use semantic descriptors only.
 
 ```php
 use BEAR\ToolUse\Runtime\AgentOptions;
@@ -204,7 +204,7 @@ $response = $agent->run(
 );
 ```
 
-You can also use ALPS transition types as a per-call tool policy. The `safeOnly()` policy exposes only tools whose matching ALPS descriptor is `safe`; tools without a matching descriptor are hidden unless you use `safeOnlyAllowingUnknownTools()`. Use `safeAndIdempotent()` when idempotent state-changing transitions are also allowed. When combining policy and context processors, place the policy first so `AlpsContextInputProcessor` describes only the tools still available after filtering.
+You can also use ALPS transition types as a per-call tool policy. The `safeOnly()` policy exposes only tools whose matching ALPS descriptor is `safe`; tools without a matching descriptor are hidden unless you use `safeOnlyAllowingUnknownTools()`. Use `safeAndIdempotent()` when idempotent state-changing transitions are also allowed. Apply this policy after the ALPS profile covers the tools you expect, or use the allowing-unknown variant during migration. When combining policy and context processors, place the policy first so `AlpsContextInputProcessor` describes only the tools still available after filtering.
 
 ```php
 $response = $agent->run(
@@ -275,6 +275,8 @@ $response = $agent->run('Tell me more about this user');
 // Clear history to start fresh
 $agent->reset();
 ```
+
+`AgentResponse::$messages` contains the conversation history snapshot when the response came from `Agent::run()`. If you call a factory such as `AgentResponse::completed($content)` directly, the history is empty unless you pass it explicitly.
 
 ### 9. Streaming Agent
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,95 @@ if ($response->completed) {
 }
 ```
 
-### 5. Conversation History
+### 5. Per-call Tool Filtering
+
+Use `AgentOptions` to limit the tools available for a single run. This does not change the collected resource registry; it only narrows the tools sent to the LLM for that invocation.
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+
+$response = $agent->run(
+    'Please search articles, but do not modify anything.',
+    AgentOptions::withTools(['article_get', 'search_get']),
+);
+```
+
+Unknown tool names fail fast, so typos or policy mistakes are detected before the LLM call.
+
+The same option is available for streaming:
+
+```php
+foreach ($agent->runStream('Search articles', AgentOptions::withTools(['search_get'])) as $event) {
+    // ...
+}
+```
+
+### 6. Input/Output Processors
+
+Processors let you extend each LLM call without making the agent runtime larger. Input processors can rewrite the system prompt, messages, or tools before the LLM call. Output processors can inspect or rewrite the LLM response after the call. They run on every iteration, including calls after tool results.
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\Message;
+
+final class MemoryProcessor implements InputProcessorInterface
+{
+    public function process(LlmRequest $request): LlmRequest
+    {
+        return $request->withMessages([
+            ...$request->messages,
+            Message::user('Known context: the user prefers concise answers.'),
+        ]);
+    }
+}
+
+$response = $agent->run(
+    'Summarize this article',
+    AgentOptions::withProcessors(inputProcessors: [new MemoryProcessor()]),
+);
+```
+
+`OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents.
+
+### 7. Agent-as-Tool / Named Subagents
+
+Register specialist agents in an `AgentPool`, then expose them as tools named `ask_{name}`. Subagent conversation history is isolated per call.
+
+```php
+use BEAR\ToolUse\Runtime\AgentDelegator;
+use BEAR\ToolUse\Runtime\AgentFactory;
+use BEAR\ToolUse\Runtime\AgentPool;
+use BEAR\ToolUse\Runtime\AgentProfile;
+
+$pool = new AgentPool($llmClient, $resourceDispatcher, $collector);
+$pool->register(new AgentProfile(
+    name: 'critic',
+    description: 'Review design risks',
+    systemPrompt: 'You are a critical reviewer.',
+    resources: ['app://self/article'],
+));
+
+$delegator = new AgentDelegator($pool, $resourceDispatcher);
+$factory = new AgentFactory($llmClient, $delegator, $collector, $registry);
+
+$agent = $factory
+    ->addResources(['app://self/article'])
+    ->addSubagents($pool)
+    ->create('You are a coordinator.');
+
+// When the LLM calls ask_critic, AgentDelegator runs the critic agent and
+// feeds the result back as a normal tool_result.
+```
+
+You can also call a subagent directly:
+
+```php
+$response = $delegator->ask('critic', 'What are the risks?', ['articleId' => 1]);
+```
+
+### 8. Conversation History
 
 The agent maintains conversation history across multiple `run()` calls.
 
@@ -156,7 +244,7 @@ $response = $agent->run('Tell me more about this user');
 $agent->reset();
 ```
 
-### 6. Streaming Agent
+### 9. Streaming Agent
 
 For real-time output (SSE, WebSocket), use the streaming agent. It yields events as the LLM generates output.
 
@@ -569,6 +657,8 @@ Errors detected by the Dispatcher:
 | `AgentInterface` | Agent runtime |
 | `StreamingAgentInterface` | Streaming agent runtime |
 | `ToolResultFilterInterface` | Response filter before sending to LLM |
+| `InputProcessorInterface` | Processes each LLM request before the call |
+| `OutputProcessorInterface` | Processes each LLM response or stream event after the call |
 | `ConfirmationHandlerInterface` | User confirmation for destructive tools |
 | `ToolCallObserverInterface` | Hook invoked once per tool dispatch (audit, metrics, latency) |
 
@@ -579,6 +669,11 @@ Errors detected by the Dispatcher:
 | `Agent` | Manages conversation loop with LLM |
 | `StreamingAgent` | Streaming conversation loop yielding `AgentEvent` |
 | `AgentFactory` | Builder for agents (sync and streaming) |
+| `AgentOptions` | Per-run options such as tool filtering |
+| `LlmRequest` | LLM request passed to input processors |
+| `AgentProfile` | Configuration for a named subagent |
+| `AgentPool` | Registry and factory for named subagents |
+| `AgentDelegator` | Dispatches `ask_*` tool calls to subagents |
 | `AgentResponse` | Agent execution result (sync) |
 | `AgentEvent` | Streaming event (`JsonSerializable`) |
 | `StreamEvent` | Low-level LLM stream event |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ $response = $agent->run(
 
 `OutputProcessorInterface` receives `LlmResponse` for normal agents and `StreamEvent` for streaming agents.
 
+You can use ALPS as runtime context with `AlpsContextInputProcessor`. It injects matching tool descriptors such as `safe` or `unsafe` transitions, plus matching semantic descriptors for tool inputs.
+
+```php
+use BEAR\ToolUse\Runtime\AgentOptions;
+use BEAR\ToolUse\Runtime\AlpsContextInputProcessor;
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+
+$alps = new AlpsSemanticDictionary(__DIR__ . '/alps/profile.json');
+
+$response = $agent->run(
+    'Find this user',
+    AgentOptions::withProcessors(inputProcessors: [
+        new AlpsContextInputProcessor($alps),
+    ]),
+);
+```
+
 ### 7. Agent-as-Tool / Named Subagents
 
 Register specialist agents in an `AgentPool`, then expose them as tools named `ask_{name}`. Subagent conversation history is isolated per call.
@@ -587,7 +604,7 @@ $dictionary = new AlpsSemanticDictionary('/path/to/profile.json');
 $converter = new SchemaConverter($dictionary);
 ```
 
-Both **JSON** and **XML** ALPS profiles are supported (format is detected from the file extension). The `title` or `doc` of `semantic` descriptors is used as the parameter description. Same-profile `href="#id"` references are resolved automatically; non-semantic descriptors (`safe` / `unsafe` / `idempotent`) are excluded.
+Both **JSON** and **XML** ALPS profiles are supported (format is detected from the file extension). The `title` or `doc` of `semantic` descriptors is used as the parameter description. Same-profile `href="#id"` references are resolved automatically. For parameter descriptions, non-semantic descriptors (`safe` / `unsafe` / `idempotent`) are excluded; `AlpsContextInputProcessor` can still use matching transition descriptors as runtime context.
 
 ## Parameter Description Priority
 
@@ -671,6 +688,7 @@ Errors detected by the Dispatcher:
 | `AgentFactory` | Builder for agents (sync and streaming) |
 | `AgentOptions` | Per-run options such as tool filtering |
 | `LlmRequest` | LLM request passed to input processors |
+| `AlpsContextInputProcessor` | Adds relevant ALPS descriptors to each LLM request |
 | `AgentProfile` | Configuration for a named subagent |
 | `AgentPool` | Registry and factory for named subagents |
 | `AgentDelegator` | Dispatches `ask_*` tool calls to subagents |

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ $response = $agent->run(
 );
 ```
 
-You can also use ALPS transition types as a per-call tool policy. The `safeOnly()` policy exposes only tools whose matching ALPS descriptor is `safe` or `idempotent`; tools without a matching descriptor are hidden unless you use `safeOnlyAllowingUnknownTools()`.
+You can also use ALPS transition types as a per-call tool policy. The `safeOnly()` policy exposes only tools whose matching ALPS descriptor is `safe`; tools without a matching descriptor are hidden unless you use `safeOnlyAllowingUnknownTools()`. Use `safeAndIdempotent()` when idempotent state-changing transitions are also allowed. When combining policy and context processors, place the policy first so `AlpsContextInputProcessor` describes only the tools still available after filtering.
 
 ```php
 $response = $agent->run(
@@ -251,6 +251,8 @@ You can also call a subagent directly:
 ```php
 $response = $delegator->ask('critic', 'What are the risks?', ['articleId' => 1]);
 ```
+
+Subagents created by `AgentPool` deny confirmable tools by default when no `ConfirmationHandlerInterface` is configured on the pool. Pass a confirmation handler to `AgentPool` when subagents should be allowed to execute `#[Tool(confirm: true)]` resources.
 
 ### 8. Conversation History
 
@@ -425,7 +427,7 @@ Y → Tool executed
 N → "User cancelled this operation." → LLM: "Understood."
 ```
 
-If no `ConfirmationHandlerInterface` is bound, confirmable tools execute normally (no blocking).
+For a directly created `Agent`, if no `ConfirmationHandlerInterface` is bound, confirmable tools execute normally (no blocking). Subagents created by `AgentPool` are stricter: without a pool-level confirmation handler, confirmable subagent tool calls are cancelled by default.
 
 ### Streaming Agent Confirmation
 
@@ -685,7 +687,9 @@ Errors detected by the Dispatcher:
 | `SchemaConverterInterface` | Converts resources to tool definitions |
 | `ToolCollectorInterface` | Collects and registers tools |
 | `AgentInterface` | Agent runtime |
+| `OptionAwareAgentInterface` | Agent runtime with per-run `AgentOptions` |
 | `StreamingAgentInterface` | Streaming agent runtime |
+| `OptionAwareStreamingAgentInterface` | Streaming agent runtime with per-run `AgentOptions` |
 | `ToolResultFilterInterface` | Response filter before sending to LLM |
 | `InputProcessorInterface` | Processes each LLM request before the call |
 | `OutputProcessorInterface` | Processes each LLM response or stream event after the call |

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,12 @@
         "test": "phpunit",
         "cs": "vendor/bin/phpcs",
         "cs-fix": "vendor/bin/phpcbf",
-        "sa": "vendor/bin/psalm --show-info=true",
+        "phpstan": "vendor/bin/phpstan analyse -c phpstan.neon --no-progress --no-interaction --memory-limit=512M",
+        "psalm": "php -d memory_limit=512M vendor/bin/psalm --show-info=true",
+        "sa": [
+            "@phpstan",
+            "@psalm"
+        ],
         "phpmd": "vendor/bin/phpmd src text phpmd.xml",
         "tests": [
             "@cs",
@@ -61,6 +66,8 @@
         "test": "Run unit tests",
         "cs": "Check coding standards",
         "cs-fix": "Fix coding standards violations",
+        "phpstan": "Run PHPStan static analysis",
+        "psalm": "Run Psalm static analysis",
         "sa": "Run static analysis",
         "phpmd": "Run mess detector",
         "tests": "Run all checks (cs, sa, test)"

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -61,7 +61,9 @@ final class Agent implements AgentInterface
 
             switch ($response->stopReason) {
                 case 'end_turn':
-                    return AgentResponse::completed($response->content);
+                    $this->recordAssistantResponse($response);
+
+                    return AgentResponse::completed($response->content, $this->messages);
 
                 case 'tool_use':
                     $this->messages[] = Message::assistant($response->content);
@@ -70,16 +72,20 @@ final class Agent implements AgentInterface
                     break;
 
                 case 'max_tokens':
-                    $this->messages[] = Message::assistant($response->content);
+                    $this->recordAssistantResponse($response);
 
                     return AgentResponse::maxTokensReached($response->content, $this->messages);
 
                 case 'stop_sequence':
+                    $this->recordAssistantResponse($response);
+
                     return AgentResponse::stopSequenceReached($response->content, $this->messages);
 
                 default:
                     // Unknown stop reason - treat as completed
-                    return AgentResponse::completed($response->content);
+                    $this->recordAssistantResponse($response);
+
+                    return AgentResponse::completed($response->content, $this->messages);
             }
         }
 
@@ -148,5 +154,14 @@ final class Agent implements AgentInterface
     {
         return $this->confirmationHandler !== null
             && $toolList->isConfirmable($toolCall->name);
+    }
+
+    private function recordAssistantResponse(LlmResponse $response): void
+    {
+        if ($response->content === []) {
+            return;
+        }
+
+        $this->messages[] = Message::assistant($response->content);
     }
 }

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -24,7 +24,6 @@ final class Agent implements AgentInterface
 {
     /** @var list<Message> */
     public array $messages = [];
-    private readonly ToolList $toolList;
 
     /** @param list<Tool> $tools */
     public function __construct(
@@ -35,7 +34,6 @@ final class Agent implements AgentInterface
         private readonly int $maxIterations = 10,
         private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
     ) {
-        $this->toolList = new ToolList($this->tools);
     }
 
     /**
@@ -44,16 +42,22 @@ final class Agent implements AgentInterface
      * Note: Messages accumulate across calls. Use reset() to clear history.
      */
     #[Override]
-    public function run(string $userMessage): AgentResponse
+    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse
     {
+        $runTools = $this->resolveTools($options);
+        $enforceToolList = $options?->enforcesToolList() ?? false;
+
         $this->messages[] = Message::user($userMessage);
 
         for ($i = 0; $i < $this->maxIterations; $i++) {
+            $request = $this->createRequest($runTools, $options);
             $response = $this->client->chat(
-                system: $this->systemPrompt,
-                messages: $this->messages,
-                tools: $this->tools,
+                system: $request->systemPrompt,
+                messages: $request->messages,
+                tools: $request->tools,
             );
+            $response = $options?->processResponse($response, $request) ?? $response;
+            $requestToolList = new ToolList($request->tools);
 
             switch ($response->stopReason) {
                 case 'end_turn':
@@ -61,7 +65,7 @@ final class Agent implements AgentInterface
 
                 case 'tool_use':
                     $this->messages[] = Message::assistant($response->content);
-                    $toolResults      = $this->processToolCalls($response);
+                    $toolResults      = $this->processToolCalls($response, $requestToolList, $enforceToolList);
                     $this->messages[] = Message::toolResults($toolResults);
                     break;
 
@@ -82,6 +86,20 @@ final class Agent implements AgentInterface
         return AgentResponse::maxIterationsReached($this->messages);
     }
 
+    /** @return list<Tool> */
+    private function resolveTools(AgentOptions|null $options): array
+    {
+        return $options?->filterTools($this->tools) ?? $this->tools;
+    }
+
+    /** @param list<Tool> $tools */
+    private function createRequest(array $tools, AgentOptions|null $options): LlmRequest
+    {
+        $request = new LlmRequest($this->systemPrompt, $this->messages, $tools);
+
+        return $options?->processRequest($request) ?? $request;
+    }
+
     /**
      * Clear conversation history to start a new conversation
      */
@@ -92,11 +110,17 @@ final class Agent implements AgentInterface
     }
 
     /** @return list<ToolResult> */
-    private function processToolCalls(LlmResponse $response): array
+    private function processToolCalls(LlmResponse $response, ToolList $toolList, bool $enforceToolList): array
     {
         $toolResults = [];
         foreach ($response->toolCalls as $toolCall) {
-            if ($this->isCancelled($toolCall, $response->getText())) {
+            if ($enforceToolList && ! $toolList->has($toolCall->name)) {
+                $toolResults[] = ToolResult::error($toolCall->id, 'Tool is not enabled: ' . $toolCall->name);
+
+                continue;
+            }
+
+            if ($this->isCancelled($toolCall, $response->getText(), $toolList)) {
                 $toolResults[] = ToolResult::cancelled($toolCall->id);
 
                 continue;
@@ -108,9 +132,9 @@ final class Agent implements AgentInterface
         return $toolResults;
     }
 
-    private function isCancelled(ToolCall $toolCall, string $llmText): bool
+    private function isCancelled(ToolCall $toolCall, string $llmText, ToolList $toolList): bool
     {
-        if (! $this->requiresConfirmation($toolCall)) {
+        if (! $this->requiresConfirmation($toolCall, $toolList)) {
             return false;
         }
 
@@ -120,9 +144,9 @@ final class Agent implements AgentInterface
         return ! $confirmationHandler->confirm($toolCall, $llmText);
     }
 
-    private function requiresConfirmation(ToolCall $toolCall): bool
+    private function requiresConfirmation(ToolCall $toolCall, ToolList $toolList): bool
     {
         return $this->confirmationHandler !== null
-            && $this->toolList->isConfirmable($toolCall->name);
+            && $toolList->isConfirmable($toolCall->name);
     }
 }

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -20,7 +20,7 @@ use function assert;
  * This agent maintains conversation state across multiple run() calls.
  * Call reset() to clear the conversation history and start fresh.
  */
-final class Agent implements AgentInterface
+final class Agent implements OptionAwareAgentInterface
 {
     /** @var list<Message> */
     public array $messages = [];
@@ -45,7 +45,6 @@ final class Agent implements AgentInterface
     public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse
     {
         $runTools = $this->resolveTools($options);
-        $enforceToolList = $options?->enforcesToolList() ?? false;
 
         $this->messages[] = Message::user($userMessage);
 
@@ -67,7 +66,7 @@ final class Agent implements AgentInterface
 
                 case 'tool_use':
                     $this->messages[] = Message::assistant($response->content);
-                    $toolResults      = $this->processToolCalls($response, $requestToolList, $enforceToolList);
+                    $toolResults      = $this->processToolCalls($response, $requestToolList);
                     $this->messages[] = Message::toolResults($toolResults);
                     break;
 
@@ -116,11 +115,11 @@ final class Agent implements AgentInterface
     }
 
     /** @return list<ToolResult> */
-    private function processToolCalls(LlmResponse $response, ToolList $toolList, bool $enforceToolList): array
+    private function processToolCalls(LlmResponse $response, ToolList $toolList): array
     {
         $toolResults = [];
         foreach ($response->toolCalls as $toolCall) {
-            if ($enforceToolList && ! $toolList->has($toolCall->name)) {
+            if (! $toolList->has($toolCall->name)) {
                 $toolResults[] = ToolResult::error($toolCall->id, 'Tool is not enabled: ' . $toolCall->name);
 
                 continue;

--- a/src/Runtime/Agent.php
+++ b/src/Runtime/Agent.php
@@ -65,7 +65,7 @@ final class Agent implements OptionAwareAgentInterface
                     return AgentResponse::completed($response->content, $this->messages);
 
                 case 'tool_use':
-                    $this->messages[] = Message::assistant($response->content);
+                    $this->recordAssistantResponse($response);
                     $toolResults      = $this->processToolCalls($response, $requestToolList);
                     $this->messages[] = Message::toolResults($toolResults);
                     break;

--- a/src/Runtime/AgentDelegator.php
+++ b/src/Runtime/AgentDelegator.php
@@ -8,6 +8,7 @@ use BEAR\ToolUse\Dispatch\DispatcherInterface;
 use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Dispatch\ToolResult;
 use Override;
+use Throwable;
 
 use function array_keys;
 use function is_array;
@@ -42,10 +43,9 @@ final readonly class AgentDelegator implements DispatcherInterface
      */
     public function ask(string $name, string $message, array $context = []): AgentResponse
     {
-        $profile = $this->pool->get($name);
         $agent = $this->pool->create($name);
 
-        return $agent->run($this->buildMessage($message, $context), $profile->options);
+        return $agent->run($this->buildMessage($message, $context));
     }
 
     public function canDispatch(string $toolName): bool
@@ -67,7 +67,8 @@ final readonly class AgentDelegator implements DispatcherInterface
 
         $agentName = $this->agentNameFromTool($toolCall->name);
         if (! $this->pool->has($agentName)) {
-            return ToolResult::error($toolCall->id, sprintf('Unknown agent: %s', $agentName));
+            return $this->fallback?->dispatch($toolCall)
+                ?? ToolResult::error($toolCall->id, sprintf('Unknown agent: %s', $agentName));
         }
 
         $message = $toolCall->input['message'] ?? null;
@@ -80,7 +81,12 @@ final readonly class AgentDelegator implements DispatcherInterface
             return ToolResult::error($toolCall->id, 'Agent tool input "context" must be an object.');
         }
 
-        $response = $this->ask($agentName, $message, $context);
+        try {
+            $response = $this->ask($agentName, $message, $context);
+        } catch (Throwable $e) {
+            return ToolResult::error($toolCall->id, $e::class . ': ' . $e->getMessage());
+        }
+
         if (! $response->completed) {
             return ToolResult::error($toolCall->id, sprintf(
                 'Subagent stopped: %s',

--- a/src/Runtime/AgentDelegator.php
+++ b/src/Runtime/AgentDelegator.php
@@ -128,6 +128,6 @@ final readonly class AgentDelegator implements DispatcherInterface
 
         $encodedContext = json_encode($context, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
-        return $message . "\n\nContext:\n" . $encodedContext;
+        return $message . "\n\n<context>\n" . $encodedContext . "\n</context>";
     }
 }

--- a/src/Runtime/AgentDelegator.php
+++ b/src/Runtime/AgentDelegator.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolResult;
+use Override;
+
+use function array_keys;
+use function is_array;
+use function is_string;
+use function json_encode;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Delegates ask_* tool calls to named subagents
+ */
+final readonly class AgentDelegator implements DispatcherInterface
+{
+    private const TOOL_PREFIX = 'ask_';
+
+    public function __construct(
+        private AgentPool $pool,
+        private DispatcherInterface|null $fallback = null,
+    ) {
+    }
+
+    /**
+     * Ask a named subagent directly.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function ask(string $name, string $message, array $context = []): AgentResponse
+    {
+        $profile = $this->pool->get($name);
+        $agent = $this->pool->create($name);
+
+        return $agent->run($this->buildMessage($message, $context), $profile->options);
+    }
+
+    public function canDispatch(string $toolName): bool
+    {
+        if (! str_starts_with($toolName, self::TOOL_PREFIX)) {
+            return false;
+        }
+
+        return $this->pool->has($this->agentNameFromTool($toolName));
+    }
+
+    #[Override]
+    public function dispatch(ToolCall $toolCall): ToolResult
+    {
+        if (! str_starts_with($toolCall->name, self::TOOL_PREFIX)) {
+            return $this->fallback?->dispatch($toolCall)
+                ?? ToolResult::error($toolCall->id, sprintf('Unknown tool: %s', $toolCall->name));
+        }
+
+        $agentName = $this->agentNameFromTool($toolCall->name);
+        if (! $this->pool->has($agentName)) {
+            return ToolResult::error($toolCall->id, sprintf('Unknown agent: %s', $agentName));
+        }
+
+        $message = $toolCall->input['message'] ?? null;
+        if (! is_string($message)) {
+            return ToolResult::error($toolCall->id, 'Agent tool input "message" must be a string.');
+        }
+
+        $context = $this->contextFromInput($toolCall->input['context'] ?? []);
+        if ($context === null) {
+            return ToolResult::error($toolCall->id, 'Agent tool input "context" must be an object.');
+        }
+
+        $response = $this->ask($agentName, $message, $context);
+        if (! $response->completed) {
+            return ToolResult::error($toolCall->id, sprintf(
+                'Subagent stopped: %s',
+                $response->stopReason,
+            ));
+        }
+
+        return ToolResult::success($toolCall->id, $response->getText());
+    }
+
+    private function agentNameFromTool(string $toolName): string
+    {
+        return substr($toolName, strlen(self::TOOL_PREFIX));
+    }
+
+    /** @return array<string, mixed>|null */
+    private function contextFromInput(mixed $context): array|null
+    {
+        if (! is_array($context)) {
+            return null;
+        }
+
+        foreach (array_keys($context) as $key) {
+            if (! is_string($key)) {
+                return null;
+            }
+        }
+
+        /** @var array<string, mixed> $context */
+        return $context;
+    }
+
+    /** @param array<string, mixed> $context */
+    private function buildMessage(string $message, array $context): string
+    {
+        if ($context === []) {
+            return $message;
+        }
+
+        $encodedContext = json_encode($context, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return $message . "\n\nContext:\n" . $encodedContext;
+    }
+}

--- a/src/Runtime/AgentFactory.php
+++ b/src/Runtime/AgentFactory.php
@@ -21,7 +21,7 @@ final class AgentFactory
 
     public function __construct(
         private readonly LlmClientInterface $client,
-        private readonly DispatcherInterface $dispatcher,
+        private DispatcherInterface $dispatcher,
         private readonly ToolCollectorInterface $collector,
         private readonly ToolRegistryInterface $registry,
         private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
@@ -67,6 +67,7 @@ final class AgentFactory
     public function addSubagents(AgentPool $pool): self
     {
         $this->addTools($pool->getTools());
+        $this->dispatcher = new AgentDelegator($pool, $this->dispatcher);
 
         return $this;
     }
@@ -74,7 +75,7 @@ final class AgentFactory
     /**
      * Create the agent
      */
-    public function create(string $systemPrompt, int $maxIterations = 10): AgentInterface
+    public function create(string $systemPrompt, int $maxIterations = 10): OptionAwareAgentInterface
     {
         return new Agent(
             client: $this->client,
@@ -89,7 +90,7 @@ final class AgentFactory
     /**
      * Create the streaming agent
      */
-    public function createStreaming(string $systemPrompt, int $maxIterations = 10): StreamingAgentInterface
+    public function createStreaming(string $systemPrompt, int $maxIterations = 10): OptionAwareStreamingAgentInterface
     {
         if ($this->streamingClient === null) {
             throw new StreamingNotConfiguredException('StreamingLlmClientInterface is not configured');

--- a/src/Runtime/AgentFactory.php
+++ b/src/Runtime/AgentFactory.php
@@ -39,9 +39,34 @@ final class AgentFactory
     public function addResources(array $uris): self
     {
         $tools = $this->collector->collect($uris);
+
+        return $this->addTools($tools);
+    }
+
+    /**
+     * Add already-built tools.
+     *
+     * @param list<Tool> $tools
+     *
+     * @return $this
+     */
+    public function addTools(array $tools): self
+    {
         foreach ($tools as $tool) {
             $this->tools[] = $tool;
         }
+
+        return $this;
+    }
+
+    /**
+     * Add named subagents as tools.
+     *
+     * @return $this
+     */
+    public function addSubagents(AgentPool $pool): self
+    {
+        $this->addTools($pool->getTools());
 
         return $this;
     }

--- a/src/Runtime/AgentInterface.php
+++ b/src/Runtime/AgentInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Runtime;
 
+use InvalidArgumentException;
+
 /**
  * Agent runtime for managing LLM conversation loop
  */
@@ -11,8 +13,10 @@ interface AgentInterface
 {
     /**
      * Run the agent with a user message
+     *
+     * @throws InvalidArgumentException When options reference unknown tools.
      */
-    public function run(string $userMessage): AgentResponse;
+    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse;
 
     /**
      * Clear conversation history to start a new conversation

--- a/src/Runtime/AgentInterface.php
+++ b/src/Runtime/AgentInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Runtime;
 
-use InvalidArgumentException;
-
 /**
  * Agent runtime for managing LLM conversation loop
  */
@@ -13,10 +11,8 @@ interface AgentInterface
 {
     /**
      * Run the agent with a user message
-     *
-     * @throws InvalidArgumentException When options reference unknown tools.
      */
-    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse;
+    public function run(string $userMessage): AgentResponse;
 
     /**
      * Clear conversation history to start a new conversation

--- a/src/Runtime/AgentOptions.php
+++ b/src/Runtime/AgentOptions.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace BEAR\ToolUse\Runtime;
 
+use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Schema\Tool;
+use BEAR\ToolUse\Types;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -16,6 +18,8 @@ use function sprintf;
 
 /**
  * Per-run agent options
+ *
+ * @psalm-import-type ContentBlock from Types
  */
 final readonly class AgentOptions
 {
@@ -53,11 +57,6 @@ final readonly class AgentOptions
     public function filtersTools(): bool
     {
         return $this->enabledTools !== null;
-    }
-
-    public function enforcesToolList(): bool
-    {
-        return $this->enabledTools !== null || $this->inputProcessors !== [];
     }
 
     /**
@@ -126,6 +125,8 @@ final readonly class AgentOptions
             }
         }
 
+        $this->assertToolUseContentIsPreserved($output);
+
         return $output;
     }
 
@@ -139,6 +140,74 @@ final readonly class AgentOptions
             }
         }
 
+        $this->assertStreamEventIsPreserved($event, $output);
+
         return $output;
+    }
+
+    private function assertToolUseContentIsPreserved(LlmResponse $response): void
+    {
+        if ($response->stopReason !== 'tool_use' || $response->toolCalls === []) {
+            return;
+        }
+
+        $toolUseBlocks = $this->toolUseBlocksById($response);
+
+        foreach ($response->toolCalls as $toolCall) {
+            if ($this->toolUseBlockMatchesToolCall($toolUseBlocks[$toolCall->id] ?? null, $toolCall)) {
+                continue;
+            }
+
+            throw new UnexpectedValueException('Output processor must preserve tool_use content blocks for tool calls.');
+        }
+    }
+
+    /** @return array<string, ContentBlock> */
+    private function toolUseBlocksById(LlmResponse $response): array
+    {
+        $toolUseBlocks = [];
+        foreach ($response->content as $block) {
+            if ($block['type'] !== 'tool_use' || ! isset($block['id'])) {
+                continue;
+            }
+
+            $toolUseBlocks[$block['id']] = $block;
+        }
+
+        return $toolUseBlocks;
+    }
+
+    /** @param array{type: string, text?: string, id?: string, name?: string, input?: array<string, mixed>}|null $block */
+    private function toolUseBlockMatchesToolCall(array|null $block, ToolCall $toolCall): bool
+    {
+        return $block !== null
+            && ($block['name'] ?? null) === $toolCall->name
+            && ($block['input'] ?? null) === $toolCall->input;
+    }
+
+    private function assertStreamEventIsPreserved(StreamEvent $input, StreamEvent $output): void
+    {
+        if ($input->type !== $output->type) {
+            throw new UnexpectedValueException('Output processor must preserve stream event type.');
+        }
+
+        foreach ($this->streamEventPreservedKeys($input->type) as $key) {
+            if (($input->data[$key] ?? null) === ($output->data[$key] ?? null)) {
+                continue;
+            }
+
+            throw new UnexpectedValueException('Output processor must preserve stream tool-use control data.');
+        }
+    }
+
+    /** @return list<string> */
+    private function streamEventPreservedKeys(string $type): array
+    {
+        return match ($type) {
+            StreamEvent::TOOL_USE_START => ['id', 'name'],
+            StreamEvent::TOOL_USE_DELTA => ['input'],
+            StreamEvent::MESSAGE_STOP => ['stopReason'],
+            default => [],
+        };
     }
 }

--- a/src/Runtime/AgentOptions.php
+++ b/src/Runtime/AgentOptions.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use UnexpectedValueException;
 
 use function array_fill_keys;
+use function count;
 use function implode;
 use function sprintf;
 
@@ -129,7 +130,7 @@ final readonly class AgentOptions
             }
         }
 
-        $this->assertToolUseContentIsPreserved($output);
+        $this->assertToolUseContentIsPreserved($response, $output);
 
         return $output;
     }
@@ -149,20 +150,47 @@ final readonly class AgentOptions
         return $output;
     }
 
-    private function assertToolUseContentIsPreserved(LlmResponse $response): void
+    private function assertToolUseContentIsPreserved(LlmResponse $input, LlmResponse $output): void
     {
-        if ($response->stopReason !== 'tool_use' || $response->toolCalls === []) {
+        if ($input->stopReason !== 'tool_use' || $input->toolCalls === []) {
             return;
         }
 
-        $toolUseBlocks = $this->toolUseBlocksById($response);
+        if ($output->stopReason !== $input->stopReason) {
+            throw new UnexpectedValueException('Output processor must preserve tool_use stop reason.');
+        }
 
-        foreach ($response->toolCalls as $toolCall) {
+        $this->assertToolCallsArePreserved($input, $output);
+
+        $toolUseBlocks = $this->toolUseBlocksById($output);
+
+        foreach ($input->toolCalls as $toolCall) {
             if ($this->toolUseBlockMatchesToolCall($toolUseBlocks[$toolCall->id] ?? null, $toolCall)) {
                 continue;
             }
 
             throw new UnexpectedValueException('Output processor must preserve tool_use content blocks for tool calls.');
+        }
+    }
+
+    private function assertToolCallsArePreserved(LlmResponse $input, LlmResponse $output): void
+    {
+        if (count($output->toolCalls) !== count($input->toolCalls)) {
+            throw new UnexpectedValueException('Output processor must preserve tool_use tool calls.');
+        }
+
+        foreach ($input->toolCalls as $index => $toolCall) {
+            $outputToolCall = $output->toolCalls[$index] ?? null;
+            if (
+                $outputToolCall instanceof ToolCall
+                && $outputToolCall->id === $toolCall->id
+                && $outputToolCall->name === $toolCall->name
+                && $outputToolCall->input === $toolCall->input
+            ) {
+                continue;
+            }
+
+            throw new UnexpectedValueException('Output processor must preserve tool_use tool calls.');
         }
     }
 

--- a/src/Runtime/AgentOptions.php
+++ b/src/Runtime/AgentOptions.php
@@ -51,7 +51,11 @@ final readonly class AgentOptions
         array $outputProcessors = [],
         array|null $enabledTools = null,
     ): self {
-        return new self($enabledTools, $inputProcessors, $outputProcessors);
+        return new self(
+            enabledTools: $enabledTools,
+            inputProcessors: $inputProcessors,
+            outputProcessors: $outputProcessors,
+        );
     }
 
     public function filtersTools(): bool

--- a/src/Runtime/AgentOptions.php
+++ b/src/Runtime/AgentOptions.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Llm\LlmResponse;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
+use UnexpectedValueException;
+
+use function array_fill_keys;
+use function implode;
+use function sprintf;
+
+/**
+ * Per-run agent options
+ */
+final readonly class AgentOptions
+{
+    /**
+     * @param list<string>|null              $enabledTools
+     * @param list<InputProcessorInterface>  $inputProcessors
+     * @param list<OutputProcessorInterface> $outputProcessors
+     */
+    public function __construct(
+        public array|null $enabledTools = null,
+        public array $inputProcessors = [],
+        public array $outputProcessors = [],
+    ) {
+    }
+
+    /** @param list<string> $toolNames */
+    public static function withTools(array $toolNames): self
+    {
+        return new self(enabledTools: $toolNames);
+    }
+
+    /**
+     * @param list<InputProcessorInterface>  $inputProcessors
+     * @param list<OutputProcessorInterface> $outputProcessors
+     * @param list<string>|null              $enabledTools
+     */
+    public static function withProcessors(
+        array $inputProcessors = [],
+        array $outputProcessors = [],
+        array|null $enabledTools = null,
+    ): self {
+        return new self($enabledTools, $inputProcessors, $outputProcessors);
+    }
+
+    public function filtersTools(): bool
+    {
+        return $this->enabledTools !== null;
+    }
+
+    public function enforcesToolList(): bool
+    {
+        return $this->enabledTools !== null || $this->inputProcessors !== [];
+    }
+
+    /**
+     * @param list<Tool> $tools
+     *
+     * @return list<Tool>
+     *
+     * @throws InvalidArgumentException When an enabled tool name is unknown.
+     */
+    public function filterTools(array $tools): array
+    {
+        if ($this->enabledTools === null) {
+            return $tools;
+        }
+
+        $knownTools = [];
+        foreach ($tools as $tool) {
+            $knownTools[$tool->name] = true;
+        }
+
+        $unknownTools = [];
+        foreach ($this->enabledTools as $toolName) {
+            if (isset($knownTools[$toolName])) {
+                continue;
+            }
+
+            $unknownTools[] = $toolName;
+        }
+
+        if ($unknownTools !== []) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown tool(s): %s',
+                implode(', ', $unknownTools),
+            ));
+        }
+
+        $enabledTools = array_fill_keys($this->enabledTools, true);
+        $filteredTools = [];
+        foreach ($tools as $tool) {
+            if (! isset($enabledTools[$tool->name])) {
+                continue;
+            }
+
+            $filteredTools[] = $tool;
+        }
+
+        return $filteredTools;
+    }
+
+    public function processRequest(LlmRequest $request): LlmRequest
+    {
+        foreach ($this->inputProcessors as $processor) {
+            $request = $processor->process($request);
+        }
+
+        return $request;
+    }
+
+    public function processResponse(LlmResponse $response, LlmRequest $request): LlmResponse
+    {
+        $output = $response;
+        foreach ($this->outputProcessors as $processor) {
+            $output = $processor->process($output, $request);
+            if (! $output instanceof LlmResponse) {
+                throw new UnexpectedValueException('Output processor must return LlmResponse for non-streaming calls.');
+            }
+        }
+
+        return $output;
+    }
+
+    public function processStreamEvent(StreamEvent $event, LlmRequest $request): StreamEvent
+    {
+        $output = $event;
+        foreach ($this->outputProcessors as $processor) {
+            $output = $processor->process($output, $request);
+            if (! $output instanceof StreamEvent) {
+                throw new UnexpectedValueException('Output processor must return StreamEvent for streaming calls.');
+            }
+        }
+
+        return $output;
+    }
+}

--- a/src/Runtime/AgentPool.php
+++ b/src/Runtime/AgentPool.php
@@ -20,6 +20,9 @@ final class AgentPool
     /** @var array<string, AgentProfile> */
     private array $profiles = [];
 
+    /** @var array<string, list<Tool>> */
+    private array $toolsByProfile = [];
+
     public function __construct(
         private readonly LlmClientInterface $client,
         private readonly DispatcherInterface $dispatcher,
@@ -31,6 +34,7 @@ final class AgentPool
     public function register(AgentProfile $profile): self
     {
         $this->profiles[$profile->name] = $profile;
+        unset($this->toolsByProfile[$profile->name]);
 
         return $this;
     }
@@ -55,7 +59,7 @@ final class AgentPool
     public function create(string $name): OptionAwareAgentInterface
     {
         $profile = $this->get($name);
-        $tools = $this->collector->collect($profile->resources);
+        $tools = $this->toolsByProfile[$name] ??= $this->collector->collect($profile->resources);
 
         $agent = new Agent(
             client: $this->client,

--- a/src/Runtime/AgentPool.php
+++ b/src/Runtime/AgentPool.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
+use BEAR\ToolUse\Llm\LlmClientInterface;
+use BEAR\ToolUse\Schema\Tool;
+use BEAR\ToolUse\Schema\ToolCollectorInterface;
+use InvalidArgumentException;
+
+use function sprintf;
+
+/**
+ * Registry and factory for named subagents
+ */
+final class AgentPool
+{
+    /** @var array<string, AgentProfile> */
+    private array $profiles = [];
+
+    public function __construct(
+        private readonly LlmClientInterface $client,
+        private readonly DispatcherInterface $dispatcher,
+        private readonly ToolCollectorInterface $collector,
+        private readonly ConfirmationHandlerInterface|null $confirmationHandler = null,
+    ) {
+    }
+
+    public function register(AgentProfile $profile): self
+    {
+        $this->profiles[$profile->name] = $profile;
+
+        return $this;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->profiles[$name]);
+    }
+
+    public function get(string $name): AgentProfile
+    {
+        if (! isset($this->profiles[$name])) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown agent: %s',
+                $name,
+            ));
+        }
+
+        return $this->profiles[$name];
+    }
+
+    public function create(string $name): AgentInterface
+    {
+        $profile = $this->get($name);
+        $tools = $this->collector->collect($profile->resources);
+
+        return new Agent(
+            client: $this->client,
+            dispatcher: $this->dispatcher,
+            tools: $tools,
+            systemPrompt: $profile->systemPrompt,
+            maxIterations: $profile->maxIterations,
+            confirmationHandler: $this->confirmationHandler,
+        );
+    }
+
+    /** @return list<Tool> */
+    public function getTools(): array
+    {
+        $tools = [];
+        foreach ($this->profiles as $profile) {
+            $tools[] = $profile->toTool();
+        }
+
+        return $tools;
+    }
+}

--- a/src/Runtime/AgentPool.php
+++ b/src/Runtime/AgentPool.php
@@ -52,19 +52,21 @@ final class AgentPool
         return $this->profiles[$name];
     }
 
-    public function create(string $name): AgentInterface
+    public function create(string $name): OptionAwareAgentInterface
     {
         $profile = $this->get($name);
         $tools = $this->collector->collect($profile->resources);
 
-        return new Agent(
+        $agent = new Agent(
             client: $this->client,
             dispatcher: $this->dispatcher,
             tools: $tools,
             systemPrompt: $profile->systemPrompt,
             maxIterations: $profile->maxIterations,
-            confirmationHandler: $this->confirmationHandler,
+            confirmationHandler: $this->confirmationHandler ?? new DenyConfirmationHandler(),
         );
+
+        return new ProfiledAgent($agent, $profile->options);
     }
 
     /** @return list<Tool> */

--- a/src/Runtime/AgentProfile.php
+++ b/src/Runtime/AgentProfile.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
+
+use function preg_match;
+use function sprintf;
+
+/**
+ * Configuration for a named subagent
+ */
+final readonly class AgentProfile
+{
+    /** @param list<string> $resources */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public string $systemPrompt,
+        public array $resources = [],
+        public int $maxIterations = 10,
+        public AgentOptions|null $options = null,
+    ) {
+        if (preg_match('/^[A-Za-z][A-Za-z0-9_]*$/', $name) !== 1) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid agent name: %s',
+                $name,
+            ));
+        }
+    }
+
+    public function toolName(): string
+    {
+        return 'ask_' . $this->name;
+    }
+
+    public function toTool(): Tool
+    {
+        return new Tool(
+            name: $this->toolName(),
+            description: $this->description,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [
+                    'message' => [
+                        'type' => 'string',
+                        'description' => 'Question or task for the subagent.',
+                    ],
+                    'context' => [
+                        'type' => 'object',
+                        'description' => 'Additional context for the subagent.',
+                    ],
+                ],
+                'required' => ['message'],
+            ],
+        );
+    }
+}

--- a/src/Runtime/AgentProfile.php
+++ b/src/Runtime/AgentProfile.php
@@ -52,6 +52,7 @@ final readonly class AgentProfile
                     'context' => [
                         'type' => 'object',
                         'description' => 'Additional context for the subagent.',
+                        'additionalProperties' => true,
                     ],
                 ],
                 'required' => ['message'],

--- a/src/Runtime/AgentResponse.php
+++ b/src/Runtime/AgentResponse.php
@@ -9,7 +9,11 @@ use function is_array;
 use function is_string;
 
 /**
- * Response from agent execution
+ * Response from agent execution.
+ *
+ * When returned by Agent::run(), `messages` is a snapshot of the conversation
+ * history at the stop point. Direct factory calls keep their default history
+ * value unless messages are passed explicitly.
  */
 final readonly class AgentResponse
 {
@@ -27,25 +31,25 @@ final readonly class AgentResponse
     ) {
     }
 
-    /** @param list<Message> $messages */
+    /** @param list<Message> $messages Conversation history to attach to the completed response. */
     public static function completed(mixed $content, array $messages = []): self
     {
         return new self(true, self::STOP_COMPLETED, $content, $messages);
     }
 
-    /** @param list<Message> $messages */
+    /** @param list<Message> $messages Conversation history at the iteration limit. */
     public static function maxIterationsReached(array $messages): self
     {
         return new self(false, self::STOP_MAX_ITERATIONS, null, $messages);
     }
 
-    /** @param list<Message> $messages */
+    /** @param list<Message> $messages Conversation history at the token limit. */
     public static function maxTokensReached(mixed $content, array $messages): self
     {
         return new self(false, self::STOP_MAX_TOKENS, $content, $messages);
     }
 
-    /** @param list<Message> $messages */
+    /** @param list<Message> $messages Conversation history at the stop sequence. */
     public static function stopSequenceReached(mixed $content, array $messages): self
     {
         return new self(false, self::STOP_STOP_SEQUENCE, $content, $messages);

--- a/src/Runtime/AgentResponse.php
+++ b/src/Runtime/AgentResponse.php
@@ -27,9 +27,10 @@ final readonly class AgentResponse
     ) {
     }
 
-    public static function completed(mixed $content): self
+    /** @param list<Message> $messages */
+    public static function completed(mixed $content, array $messages = []): self
     {
-        return new self(true, self::STOP_COMPLETED, $content, []);
+        return new self(true, self::STOP_COMPLETED, $content, $messages);
     }
 
     /** @param list<Message> $messages */

--- a/src/Runtime/AlpsContextInputProcessor.php
+++ b/src/Runtime/AlpsContextInputProcessor.php
@@ -15,7 +15,12 @@ use function str_replace;
 use function ucwords;
 
 /**
- * Adds ALPS semantic context for the tools available in an LLM call
+ * Adds ALPS semantic context for the tools available in an LLM call.
+ *
+ * Tool descriptions are resolved from ALPS descriptors whose id matches the tool
+ * name (or its camelCase form), including transition descriptors such as `safe`
+ * and `unsafe`. Parameter descriptions are resolved only from semantic
+ * descriptors whose id matches the input parameter name.
  */
 final readonly class AlpsContextInputProcessor implements InputProcessorInterface
 {

--- a/src/Runtime/AlpsContextInputProcessor.php
+++ b/src/Runtime/AlpsContextInputProcessor.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use Override;
+
+use function array_keys;
+use function implode;
+use function lcfirst;
+use function str_replace;
+use function ucwords;
+
+/**
+ * Adds ALPS semantic context for the tools available in an LLM call
+ */
+final readonly class AlpsContextInputProcessor implements InputProcessorInterface
+{
+    public function __construct(
+        private AlpsSemanticDictionary $dictionary,
+        private string $heading = 'Application semantics from ALPS:',
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $lines = $this->buildLines($request->tools);
+        if ($lines === []) {
+            return $request;
+        }
+
+        return $request->withMessages([
+            ...$request->messages,
+            Message::user($this->heading . "\n" . implode("\n", $lines)),
+        ]);
+    }
+
+    /**
+     * @param list<Tool> $tools
+     *
+     * @return list<string>
+     */
+    private function buildLines(array $tools): array
+    {
+        $lines = [];
+        $seen = [];
+        foreach ($tools as $tool) {
+            $this->addToolLine($tool, $lines, $seen);
+            $this->addParameterLines($tool, $lines, $seen);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param list<string>        $lines
+     * @param array<string, true> $seen
+     */
+    private function addToolLine(Tool $tool, array &$lines, array &$seen): void
+    {
+        $descriptor = $this->resolveDescriptor($tool->name);
+        if ($descriptor === null || $descriptor['description'] === null) {
+            return;
+        }
+
+        $key = $tool->name;
+        if ($descriptor['type'] !== 'semantic') {
+            $key .= ' [' . $descriptor['type'] . ']';
+        }
+
+        $this->addLine($key, $descriptor['description'], $lines, $seen);
+    }
+
+    /**
+     * @param list<string>        $lines
+     * @param array<string, true> $seen
+     */
+    private function addParameterLines(Tool $tool, array &$lines, array &$seen): void
+    {
+        foreach (array_keys($tool->inputSchema['properties']) as $paramName) {
+            $description = $this->resolveDescription($paramName);
+            if ($description === null) {
+                continue;
+            }
+
+            $this->addLine($tool->name . '.' . $paramName, $description, $lines, $seen);
+        }
+    }
+
+    private function resolveDescription(string $id): string|null
+    {
+        $description = $this->dictionary->get($id);
+        if ($description !== null) {
+            return $description;
+        }
+
+        return $this->dictionary->get($this->toCamelCase($id));
+    }
+
+    /** @return array{id: string, type: string, description: string|null, href: string|null}|null */
+    private function resolveDescriptor(string $id): array|null
+    {
+        $descriptor = $this->dictionary->getDescriptor($id);
+        if ($descriptor !== null) {
+            return $descriptor;
+        }
+
+        return $this->dictionary->getDescriptor($this->toCamelCase($id));
+    }
+
+    private function toCamelCase(string $id): string
+    {
+        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $id))));
+    }
+
+    /**
+     * @param list<string>        $lines
+     * @param array<string, true> $seen
+     */
+    private function addLine(string $key, string $description, array &$lines, array &$seen): void
+    {
+        if (isset($seen[$key])) {
+            return;
+        }
+
+        $lines[] = '- ' . $key . ': ' . $description;
+        $seen[$key] = true;
+    }
+}

--- a/src/Runtime/AlpsToolPolicyInputProcessor.php
+++ b/src/Runtime/AlpsToolPolicyInputProcessor.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use Override;
+
+use function in_array;
+use function lcfirst;
+use function str_replace;
+use function ucwords;
+
+/** Filters available tools by matching ALPS descriptor types */
+final readonly class AlpsToolPolicyInputProcessor implements InputProcessorInterface
+{
+    public const UNKNOWN_TOOLS_HIDDEN = 'hidden';
+    public const UNKNOWN_TOOLS_ALLOWED = 'allowed';
+
+    /**
+     * @param list<string>                                           $allowedTypes
+     * @param self::UNKNOWN_TOOLS_HIDDEN|self::UNKNOWN_TOOLS_ALLOWED $unknownToolPolicy
+     */
+    public function __construct(
+        private AlpsSemanticDictionary $dictionary,
+        private array $allowedTypes,
+        private string $unknownToolPolicy = self::UNKNOWN_TOOLS_HIDDEN,
+    ) {
+    }
+
+    public static function safeOnly(AlpsSemanticDictionary $dictionary): self
+    {
+        return new self($dictionary, ['safe', 'idempotent']);
+    }
+
+    public static function safeOnlyAllowingUnknownTools(AlpsSemanticDictionary $dictionary): self
+    {
+        return new self($dictionary, ['safe', 'idempotent'], self::UNKNOWN_TOOLS_ALLOWED);
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $tools = [];
+        foreach ($request->tools as $tool) {
+            if (! $this->allows($tool)) {
+                continue;
+            }
+
+            $tools[] = $tool;
+        }
+
+        if ($tools === $request->tools) {
+            return $request;
+        }
+
+        return $request->withTools($tools);
+    }
+
+    private function allows(Tool $tool): bool
+    {
+        $descriptor = $this->resolveDescriptor($tool->name);
+        if ($descriptor === null) {
+            return $this->unknownToolPolicy === self::UNKNOWN_TOOLS_ALLOWED;
+        }
+
+        return in_array($descriptor['type'], $this->allowedTypes, true);
+    }
+
+    /** @return array{id: string, type: string, description: string|null, href: string|null}|null */
+    private function resolveDescriptor(string $id): array|null
+    {
+        $descriptor = $this->dictionary->getDescriptor($id);
+        if ($descriptor !== null) {
+            return $descriptor;
+        }
+
+        return $this->dictionary->getDescriptor($this->toCamelCase($id));
+    }
+
+    private function toCamelCase(string $id): string
+    {
+        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $id))));
+    }
+}

--- a/src/Runtime/AlpsToolPolicyInputProcessor.php
+++ b/src/Runtime/AlpsToolPolicyInputProcessor.php
@@ -13,7 +13,13 @@ use function lcfirst;
 use function str_replace;
 use function ucwords;
 
-/** Filters available tools by matching ALPS descriptor types */
+/**
+ * Filters available tools by matching ALPS descriptor types.
+ *
+ * Tool names must match ALPS descriptor ids (or their camelCase form). Tools
+ * without a matching descriptor are hidden unless an allowing-unknown factory is
+ * used.
+ */
 final readonly class AlpsToolPolicyInputProcessor implements InputProcessorInterface
 {
     public const UNKNOWN_TOOLS_HIDDEN = 'hidden';

--- a/src/Runtime/AlpsToolPolicyInputProcessor.php
+++ b/src/Runtime/AlpsToolPolicyInputProcessor.php
@@ -32,10 +32,20 @@ final readonly class AlpsToolPolicyInputProcessor implements InputProcessorInter
 
     public static function safeOnly(AlpsSemanticDictionary $dictionary): self
     {
-        return new self($dictionary, ['safe', 'idempotent']);
+        return new self($dictionary, ['safe']);
     }
 
     public static function safeOnlyAllowingUnknownTools(AlpsSemanticDictionary $dictionary): self
+    {
+        return new self($dictionary, ['safe'], self::UNKNOWN_TOOLS_ALLOWED);
+    }
+
+    public static function safeAndIdempotent(AlpsSemanticDictionary $dictionary): self
+    {
+        return new self($dictionary, ['safe', 'idempotent']);
+    }
+
+    public static function safeAndIdempotentAllowingUnknownTools(AlpsSemanticDictionary $dictionary): self
     {
         return new self($dictionary, ['safe', 'idempotent'], self::UNKNOWN_TOOLS_ALLOWED);
     }

--- a/src/Runtime/DenyConfirmationHandler.php
+++ b/src/Runtime/DenyConfirmationHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Dispatch\ToolCall;
+use Override;
+
+/**
+ * Confirmation handler that denies every confirmable tool call.
+ */
+final readonly class DenyConfirmationHandler implements ConfirmationHandlerInterface
+{
+    #[Override]
+    public function confirm(ToolCall $toolCall, string $llmText): bool
+    {
+        return false;
+    }
+}

--- a/src/Runtime/InputProcessorInterface.php
+++ b/src/Runtime/InputProcessorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+/**
+ * Processes an LLM request before each LLM call
+ */
+interface InputProcessorInterface
+{
+    public function process(LlmRequest $request): LlmRequest;
+}

--- a/src/Runtime/LlmRequest.php
+++ b/src/Runtime/LlmRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\Tool;
+
+/**
+ * Request passed to an LLM call
+ */
+final readonly class LlmRequest
+{
+    /**
+     * @param list<Message> $messages
+     * @param list<Tool>    $tools
+     */
+    public function __construct(
+        public string $systemPrompt,
+        public array $messages,
+        public array $tools,
+    ) {
+    }
+
+    public function withSystemPrompt(string $systemPrompt): self
+    {
+        return new self($systemPrompt, $this->messages, $this->tools);
+    }
+
+    /** @param list<Message> $messages */
+    public function withMessages(array $messages): self
+    {
+        return new self($this->systemPrompt, $messages, $this->tools);
+    }
+
+    /** @param list<Tool> $tools */
+    public function withTools(array $tools): self
+    {
+        return new self($this->systemPrompt, $this->messages, $tools);
+    }
+}

--- a/src/Runtime/OptionAwareAgentInterface.php
+++ b/src/Runtime/OptionAwareAgentInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use InvalidArgumentException;
+use Override;
+
+/**
+ * Agent runtime that supports per-run options.
+ */
+interface OptionAwareAgentInterface extends AgentInterface
+{
+    /**
+     * Run the agent with a user message and optional per-run controls.
+     *
+     * @throws InvalidArgumentException When options reference unknown tools.
+     */
+    #[Override]
+    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse;
+}

--- a/src/Runtime/OptionAwareStreamingAgentInterface.php
+++ b/src/Runtime/OptionAwareStreamingAgentInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use Generator;
+use InvalidArgumentException;
+use Override;
+
+/**
+ * Streaming agent runtime that supports per-run options.
+ */
+interface OptionAwareStreamingAgentInterface extends StreamingAgentInterface
+{
+    /**
+     * Run the agent with streaming output and optional per-run controls.
+     *
+     * @return Generator<int, AgentEvent, mixed, void>
+     *
+     * @throws InvalidArgumentException When options reference unknown tools.
+     */
+    #[Override]
+    public function runStream(string $userMessage, AgentOptions|null $options = null): Generator;
+}

--- a/src/Runtime/OutputProcessorInterface.php
+++ b/src/Runtime/OutputProcessorInterface.php
@@ -8,7 +8,13 @@ use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Llm\StreamEvent;
 
 /**
- * Processes an LLM response after each LLM call
+ * Processes an LLM response or stream event after each LLM call.
+ *
+ * Implementations must return the same concrete type they receive: `LlmResponse`
+ * for normal agent calls and `StreamEvent` for streaming calls. Processors may
+ * rewrite text content, but must preserve tool-use control data (`tool_use`
+ * content blocks and stream tool-use ids/names/input) so the agent can dispatch
+ * tools safely.
  */
 interface OutputProcessorInterface
 {

--- a/src/Runtime/OutputProcessorInterface.php
+++ b/src/Runtime/OutputProcessorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Llm\LlmResponse;
+use BEAR\ToolUse\Llm\StreamEvent;
+
+/**
+ * Processes an LLM response after each LLM call
+ */
+interface OutputProcessorInterface
+{
+    public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent;
+}

--- a/src/Runtime/ProfiledAgent.php
+++ b/src/Runtime/ProfiledAgent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use Override;
+
+/**
+ * Agent wrapper that applies profile default options.
+ */
+final readonly class ProfiledAgent implements OptionAwareAgentInterface
+{
+    public function __construct(
+        private Agent $agent,
+        private AgentOptions|null $defaultOptions,
+    ) {
+    }
+
+    #[Override]
+    public function run(string $userMessage, AgentOptions|null $options = null): AgentResponse
+    {
+        return $this->agent->run($userMessage, $options ?? $this->defaultOptions);
+    }
+
+    #[Override]
+    public function reset(): void
+    {
+        $this->agent->reset();
+    }
+}

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -109,6 +109,8 @@ final class StreamingAgent implements StreamingAgentInterface
             }
 
             // Other stop reasons (max_tokens, stop_sequence) - complete
+            $this->recordContentBlocks($state);
+
             yield AgentEvent::completed($fullText);
 
             return;

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -31,7 +31,6 @@ final class StreamingAgent implements StreamingAgentInterface
 {
     /** @var list<Message> */
     public array $messages = [];
-    private readonly ToolList $toolList;
 
     /** @param list<Tool> $tools */
     public function __construct(
@@ -41,23 +40,28 @@ final class StreamingAgent implements StreamingAgentInterface
         private readonly string $systemPrompt,
         private readonly int $maxIterations = 10,
     ) {
-        $this->toolList = new ToolList($this->tools);
     }
 
     /** @return Generator<int, AgentEvent, mixed, void> */
     #[Override]
-    public function runStream(string $userMessage): Generator
+    public function runStream(string $userMessage, AgentOptions|null $options = null): Generator
     {
+        $runTools = $this->resolveTools($options);
+        $enforceToolList = $options?->enforcesToolList() ?? false;
+
         $this->messages[] = Message::user($userMessage);
         $fullText = '';
         $hadPreviousText = false;
 
         for ($i = 0; $i < $this->maxIterations; $i++) {
+            $request = $this->createRequest($runTools, $options);
             $stream = $this->client->chatStream(
-                system: $this->systemPrompt,
-                messages: $this->messages,
-                tools: $this->tools,
+                system: $request->systemPrompt,
+                messages: $request->messages,
+                tools: $request->tools,
             );
+            $stream = $this->processStream($stream, $request, $options);
+            $requestToolList = new ToolList($request->tools);
 
             $consumeGen = $this->consumeStream($stream, $hadPreviousText, $fullText);
             foreach ($consumeGen as $event) {
@@ -78,7 +82,12 @@ final class StreamingAgent implements StreamingAgentInterface
             if ($state->stopReason === 'tool_use' && $state->pendingToolCalls !== []) {
                 $this->messages[] = Message::assistant($state->contentBlocks);
 
-                $dispatchGen = $this->dispatchPendingToolCalls($state->pendingToolCalls, $state->currentText);
+                $dispatchGen = $this->dispatchPendingToolCalls(
+                    $state->pendingToolCalls,
+                    $state->currentText,
+                    $requestToolList,
+                    $enforceToolList,
+                );
                 while ($dispatchGen->valid()) {
                     /** @var AgentEvent $currentEvent */
                     $currentEvent = $dispatchGen->current();
@@ -123,6 +132,32 @@ final class StreamingAgent implements StreamingAgentInterface
         $this->messages[] = Message::assistant($state->contentBlocks);
     }
 
+    /** @return list<Tool> */
+    private function resolveTools(AgentOptions|null $options): array
+    {
+        return $options?->filterTools($this->tools) ?? $this->tools;
+    }
+
+    /** @param list<Tool> $tools */
+    private function createRequest(array $tools, AgentOptions|null $options): LlmRequest
+    {
+        $request = new LlmRequest($this->systemPrompt, $this->messages, $tools);
+
+        return $options?->processRequest($request) ?? $request;
+    }
+
+    /**
+     * @param Generator<int, StreamEvent, mixed, void> $stream
+     *
+     * @return Generator<int, StreamEvent, mixed, void>
+     */
+    private function processStream(Generator $stream, LlmRequest $request, AgentOptions|null $options): Generator
+    {
+        foreach ($stream as $event) {
+            yield $options?->processStreamEvent($event, $request) ?? $event;
+        }
+    }
+
     /**
      * Consume stream events and yield AgentEvents
      *
@@ -151,8 +186,12 @@ final class StreamingAgent implements StreamingAgentInterface
      *
      * @return Generator<int, AgentEvent, bool, list<ToolResult>>
      */
-    private function dispatchPendingToolCalls(array $pendingToolCalls, string $currentText): Generator
-    {
+    private function dispatchPendingToolCalls(
+        array $pendingToolCalls,
+        string $currentText,
+        ToolList $toolList,
+        bool $enforceToolList,
+    ): Generator {
         $toolResults = [];
         foreach ($pendingToolCalls as $pending) {
             /** @var array<string, mixed> $input */
@@ -163,7 +202,15 @@ final class StreamingAgent implements StreamingAgentInterface
                 input: $input,
             );
 
-            if ($this->toolList->isConfirmable($toolCall->name)) {
+            if ($enforceToolList && ! $toolList->has($toolCall->name)) {
+                $toolResults[] = ToolResult::error($toolCall->id, 'Tool is not enabled: ' . $toolCall->name);
+
+                yield AgentEvent::toolResult($pending->name);
+
+                continue;
+            }
+
+            if ($toolList->isConfirmable($toolCall->name)) {
                 /** @var bool $approved */
                 $approved = yield AgentEvent::confirmationRequired(
                     $toolCall->name,

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -106,7 +106,7 @@ final class StreamingAgent implements OptionAwareStreamingAgentInterface
                 continue;
             }
 
-            // Other stop reasons (max_tokens, stop_sequence) - complete
+            // Any terminal stop reason without pending tools is returned as a completed stream.
             $this->recordContentBlocks($state);
 
             yield AgentEvent::completed($fullText);

--- a/src/Runtime/StreamingAgent.php
+++ b/src/Runtime/StreamingAgent.php
@@ -27,7 +27,7 @@ use function json_decode;
  * receives approval via Generator::send(bool). If send() is not called
  * (e.g. iterator_to_array), the tool is denied by default (safe default).
  */
-final class StreamingAgent implements StreamingAgentInterface
+final class StreamingAgent implements OptionAwareStreamingAgentInterface
 {
     /** @var list<Message> */
     public array $messages = [];
@@ -47,7 +47,6 @@ final class StreamingAgent implements StreamingAgentInterface
     public function runStream(string $userMessage, AgentOptions|null $options = null): Generator
     {
         $runTools = $this->resolveTools($options);
-        $enforceToolList = $options?->enforcesToolList() ?? false;
 
         $this->messages[] = Message::user($userMessage);
         $fullText = '';
@@ -86,7 +85,6 @@ final class StreamingAgent implements StreamingAgentInterface
                     $state->pendingToolCalls,
                     $state->currentText,
                     $requestToolList,
-                    $enforceToolList,
                 );
                 while ($dispatchGen->valid()) {
                     /** @var AgentEvent $currentEvent */
@@ -192,7 +190,6 @@ final class StreamingAgent implements StreamingAgentInterface
         array $pendingToolCalls,
         string $currentText,
         ToolList $toolList,
-        bool $enforceToolList,
     ): Generator {
         $toolResults = [];
         foreach ($pendingToolCalls as $pending) {
@@ -204,7 +201,7 @@ final class StreamingAgent implements StreamingAgentInterface
                 input: $input,
             );
 
-            if ($enforceToolList && ! $toolList->has($toolCall->name)) {
+            if (! $toolList->has($toolCall->name)) {
                 $toolResults[] = ToolResult::error($toolCall->id, 'Tool is not enabled: ' . $toolCall->name);
 
                 yield AgentEvent::toolResult($pending->name);

--- a/src/Runtime/StreamingAgentInterface.php
+++ b/src/Runtime/StreamingAgentInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\ToolUse\Runtime;
 
 use Generator;
-use InvalidArgumentException;
 
 /**
  * Streaming agent runtime
@@ -16,10 +15,8 @@ interface StreamingAgentInterface
      * Run the agent with streaming output
      *
      * @return Generator<int, AgentEvent, mixed, void>
-     *
-     * @throws InvalidArgumentException When options reference unknown tools.
      */
-    public function runStream(string $userMessage, AgentOptions|null $options = null): Generator;
+    public function runStream(string $userMessage): Generator;
 
     /**
      * Clear conversation history

--- a/src/Runtime/StreamingAgentInterface.php
+++ b/src/Runtime/StreamingAgentInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ToolUse\Runtime;
 
 use Generator;
+use InvalidArgumentException;
 
 /**
  * Streaming agent runtime
@@ -15,8 +16,10 @@ interface StreamingAgentInterface
      * Run the agent with streaming output
      *
      * @return Generator<int, AgentEvent, mixed, void>
+     *
+     * @throws InvalidArgumentException When options reference unknown tools.
      */
-    public function runStream(string $userMessage): Generator;
+    public function runStream(string $userMessage, AgentOptions|null $options = null): Generator;
 
     /**
      * Clear conversation history

--- a/src/Runtime/ToolList.php
+++ b/src/Runtime/ToolList.php
@@ -14,13 +14,18 @@ use function array_key_exists;
 final readonly class ToolList
 {
     /** @var array<string, bool> */
+    private array $available;
+
+    /** @var array<string, bool> */
     private array $confirmable;
 
     /** @param list<Tool> $tools */
     public function __construct(array $tools)
     {
+        $available = [];
         $confirmable = [];
         foreach ($tools as $tool) {
+            $available[$tool->name] = true;
             if (! $tool->confirm) {
                 continue;
             }
@@ -28,7 +33,13 @@ final readonly class ToolList
             $confirmable[$tool->name] = true;
         }
 
+        $this->available = $available;
         $this->confirmable = $confirmable;
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->available);
     }
 
     public function isConfirmable(string $name): bool

--- a/src/Schema/AlpsDescriptorIndex.php
+++ b/src/Schema/AlpsDescriptorIndex.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Schema;
+
+use function str_starts_with;
+use function substr;
+
+/** @phpstan-type Entry array{id: string, type: string, description: string|null, href: string|null} */
+final class AlpsDescriptorIndex
+{
+    /** Maximum href chain depth (e.g. A -> B -> C). Guards against cycles. */
+    private const HREF_RESOLUTION_DEPTH = 10;
+
+    /** @var array<string, Entry> */
+    private array $descriptors;
+
+    /** @param list<Entry> $entries */
+    public function __construct(array $entries)
+    {
+        $this->descriptors = $this->buildDescriptorMap($entries);
+    }
+
+    /** @return Entry|null */
+    public function get(string $id): array|null
+    {
+        return $this->descriptors[$id] ?? null;
+    }
+
+    /** @return array<string, string> */
+    public function semanticDictionary(): array
+    {
+        $dictionary = [];
+        foreach ($this->descriptors as $entry) {
+            if ($entry['type'] !== 'semantic' || $entry['description'] === null) {
+                continue;
+            }
+
+            $dictionary[$entry['id']] = $entry['description'];
+        }
+
+        return $dictionary;
+    }
+
+    /**
+     * @param list<Entry> $entries
+     *
+     * @return array<string, Entry>
+     */
+    private function buildDescriptorMap(array $entries): array
+    {
+        $descriptors = [];
+        foreach ($entries as $entry) {
+            $descriptors[$entry['id']] = $entry;
+        }
+
+        for ($depth = 0; $depth < self::HREF_RESOLUTION_DEPTH; $depth++) {
+            if (! $this->resolveHrefPass($descriptors)) {
+                break;
+            }
+        }
+
+        return $descriptors;
+    }
+
+    /** @param array<string, Entry> $descriptors */
+    private function resolveHrefPass(array &$descriptors): bool
+    {
+        $changed = false;
+        foreach ($descriptors as $id => $entry) {
+            if ($entry['description'] !== null) {
+                continue;
+            }
+
+            $href = $entry['href'];
+            if ($href === null) {
+                continue;
+            }
+
+            if (! str_starts_with($href, '#')) {
+                continue;
+            }
+
+            $referencedId = substr($href, 1);
+            if (! isset($descriptors[$referencedId])) {
+                continue;
+            }
+
+            $referencedDescription = $descriptors[$referencedId]['description'];
+            if ($referencedDescription === null) {
+                continue;
+            }
+
+            $descriptors[$id]['description'] = $referencedDescription;
+            $changed = true;
+        }
+
+        return $changed;
+    }
+}

--- a/src/Schema/AlpsDescriptorIndex.php
+++ b/src/Schema/AlpsDescriptorIndex.php
@@ -7,7 +7,10 @@ namespace BEAR\ToolUse\Schema;
 use function str_starts_with;
 use function substr;
 
-/** @phpstan-type Entry array{id: string, type: string, description: string|null, href: string|null} */
+/**
+ * @phpstan-type Entry array{id: string, type: string, description: string|null, href: string|null}
+ * @psalm-type Entry = array{id: string, type: string, description: string|null, href: string|null}
+ */
 final class AlpsDescriptorIndex
 {
     /** Maximum href chain depth (e.g. A -> B -> C). Guards against cycles. */

--- a/src/Schema/AlpsSemanticDictionary.php
+++ b/src/Schema/AlpsSemanticDictionary.php
@@ -22,9 +22,7 @@ use function libxml_use_internal_errors;
 use function pathinfo;
 use function simplexml_load_string;
 use function sprintf;
-use function str_starts_with;
 use function strtolower;
-use function substr;
 use function trim;
 
 use const JSON_THROW_ON_ERROR;
@@ -35,9 +33,10 @@ use const PATHINFO_EXTENSION;
  *
  * Parses an ALPS profile (JSON or XML) and exposes an
  * `id` => description mapping for semantic descriptors.
+ * Full descriptors, including transitions, are available through getDescriptor().
  *
  * Behavior matches koriym/app-state-diagram for the subset we need:
- *  - Only `type === 'semantic'` descriptors are included (transitions excluded).
+ *  - Only `type === 'semantic'` descriptors are included in the array mapping.
  *  - Same-profile `href="#id"` references resolve to the referenced description.
  *  - Cross-file href references are not supported.
  *
@@ -46,8 +45,7 @@ use const PATHINFO_EXTENSION;
  */
 final class AlpsSemanticDictionary extends ArrayObject
 {
-    /** Maximum href chain depth (e.g. A -> B -> C). Guards against cycles. */
-    private const HREF_RESOLUTION_DEPTH = 10;
+    private AlpsDescriptorIndex $descriptorIndex;
 
     public function __construct(string $profilePath)
     {
@@ -60,7 +58,9 @@ final class AlpsSemanticDictionary extends ArrayObject
             ),
         };
 
-        parent::__construct($this->buildDictionary($entries));
+        $this->descriptorIndex = new AlpsDescriptorIndex($entries);
+
+        parent::__construct($this->descriptorIndex->semanticDictionary());
     }
 
     public function get(string $key): string|null
@@ -68,71 +68,10 @@ final class AlpsSemanticDictionary extends ArrayObject
         return $this[$key] ?? null;
     }
 
-    /**
-     * @param list<Entry> $entries
-     *
-     * @return array<string, string>
-     */
-    private function buildDictionary(array $entries): array
+    /** @return Entry|null */
+    public function getDescriptor(string $id): array|null
     {
-        $semanticEntries = [];
-        foreach ($entries as $entry) {
-            if ($entry['type'] !== 'semantic') {
-                continue;
-            }
-
-            $semanticEntries[] = $entry;
-        }
-
-        $dictionary = [];
-        foreach ($semanticEntries as $entry) {
-            if ($entry['description'] === null) {
-                continue;
-            }
-
-            $dictionary[$entry['id']] = $entry['description'];
-        }
-
-        for ($depth = 0; $depth < self::HREF_RESOLUTION_DEPTH; $depth++) {
-            if (! $this->resolveHrefPass($semanticEntries, $dictionary)) {
-                break;
-            }
-        }
-
-        return $dictionary;
-    }
-
-    /**
-     * @param list<Entry>           $semanticEntries
-     * @param array<string, string> $dictionary
-     */
-    private function resolveHrefPass(array $semanticEntries, array &$dictionary): bool
-    {
-        $changed = false;
-        foreach ($semanticEntries as $entry) {
-            if (isset($dictionary[$entry['id']])) {
-                continue;
-            }
-
-            $href = $entry['href'];
-            if ($href === null) {
-                continue;
-            }
-
-            if (! str_starts_with($href, '#')) {
-                continue;
-            }
-
-            $referencedId = substr($href, 1);
-            if (! isset($dictionary[$referencedId])) {
-                continue;
-            }
-
-            $dictionary[$entry['id']] = $dictionary[$referencedId];
-            $changed = true;
-        }
-
-        return $changed;
+        return $this->descriptorIndex->get($id);
     }
 
     /** @return list<Entry> */

--- a/tests/Fake/FakeInputProcessor.php
+++ b/tests/Fake/FakeInputProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\Message;
+use Override;
+
+/**
+ * Fake input processor for testing
+ */
+final class FakeInputProcessor implements InputProcessorInterface
+{
+    public int $calls = 0;
+
+    public function __construct(
+        private readonly string $systemSuffix = '',
+        private readonly string $memoryText = 'memory',
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $this->calls++;
+
+        return $request
+            ->withSystemPrompt($request->systemPrompt . $this->systemSuffix)
+            ->withMessages([...$request->messages, Message::user($this->memoryText)]);
+    }
+}

--- a/tests/Fake/FakeOutputProcessor.php
+++ b/tests/Fake/FakeOutputProcessor.php
@@ -28,6 +28,17 @@ final class FakeOutputProcessor implements OutputProcessorInterface
         $this->calls++;
 
         if ($output instanceof LlmResponse) {
+            if ($output->stopReason === 'tool_use') {
+                $content = [];
+                foreach ($output->content as $block) {
+                    $content[] = ($block['type'] ?? null) === 'text'
+                        ? ['type' => 'text', 'text' => $this->replacementText]
+                        : $block;
+                }
+
+                return new LlmResponse($output->stopReason, $content, $output->toolCalls);
+            }
+
             return new LlmResponse(
                 $output->stopReason,
                 [['type' => 'text', 'text' => $this->replacementText]],

--- a/tests/Fake/FakeOutputProcessor.php
+++ b/tests/Fake/FakeOutputProcessor.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Llm\LlmResponse;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Runtime\OutputProcessorInterface;
+use Override;
+
+/**
+ * Fake output processor for testing
+ */
+final class FakeOutputProcessor implements OutputProcessorInterface
+{
+    public int $calls = 0;
+
+    public function __construct(
+        private readonly string $replacementText,
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+    {
+        $this->calls++;
+
+        if ($output instanceof LlmResponse) {
+            return new LlmResponse(
+                $output->stopReason,
+                [['type' => 'text', 'text' => $this->replacementText]],
+                $output->toolCalls,
+            );
+        }
+
+        if ($output->type !== StreamEvent::TEXT_DELTA) {
+            return $output;
+        }
+
+        return new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => $this->replacementText]);
+    }
+}

--- a/tests/Fake/FakeToolFilteringInputProcessor.php
+++ b/tests/Fake/FakeToolFilteringInputProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Fake;
+
+use BEAR\ToolUse\Runtime\InputProcessorInterface;
+use BEAR\ToolUse\Runtime\LlmRequest;
+use BEAR\ToolUse\Schema\Tool;
+use Override;
+
+/**
+ * Fake tool filtering input processor for testing
+ */
+final readonly class FakeToolFilteringInputProcessor implements InputProcessorInterface
+{
+    public function __construct(
+        private string $enabledTool,
+    ) {
+    }
+
+    #[Override]
+    public function process(LlmRequest $request): LlmRequest
+    {
+        $tools = [];
+        foreach ($request->tools as $tool) {
+            if ($tool->name !== $this->enabledTool) {
+                continue;
+            }
+
+            $tools[] = $tool;
+        }
+
+        /** @var list<Tool> $tools */
+        return $request->withTools($tools);
+    }
+}

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -41,6 +41,16 @@
         "title": "Create user transition"
       },
       {
+        "id": "syncUser",
+        "type": "idempotent",
+        "title": "Synchronize user transition"
+      },
+      {
+        "id": "deleteUser",
+        "type": "unsafe",
+        "title": "Delete user transition"
+      },
+      {
         "id": "userIdAlias",
         "type": "semantic",
         "href": "#userId"

--- a/tests/Fake/alps-profile.json
+++ b/tests/Fake/alps-profile.json
@@ -36,19 +36,38 @@
         ]
       },
       {
-        "id": "createUser",
+        "id": "UserList",
+        "type": "semantic",
+        "title": "User list state"
+      },
+      {
+        "id": "User",
+        "type": "semantic",
+        "title": "User detail state"
+      },
+      {
+        "id": "goUserList",
         "type": "safe",
-        "title": "Create user transition"
+        "title": "Open user list transition",
+        "rt": "#UserList"
       },
       {
-        "id": "syncUser",
+        "id": "doSyncUser",
         "type": "idempotent",
-        "title": "Synchronize user transition"
+        "title": "Synchronize user transition",
+        "rt": "#User"
       },
       {
-        "id": "deleteUser",
+        "id": "doDeleteUser",
+        "type": "idempotent",
+        "title": "Delete user transition",
+        "rt": "#UserList"
+      },
+      {
+        "id": "doCreateUser",
         "type": "unsafe",
-        "title": "Delete user transition"
+        "title": "Create user transition",
+        "rt": "#User"
       },
       {
         "id": "userIdAlias",

--- a/tests/Fake/alps-profile.xml
+++ b/tests/Fake/alps-profile.xml
@@ -11,9 +11,12 @@
       <doc>Nested description</doc>
     </descriptor>
   </descriptor>
-  <descriptor id="createUser" type="safe" title="Create user transition"/>
-  <descriptor id="syncUser" type="idempotent" title="Synchronize user transition"/>
-  <descriptor id="deleteUser" type="unsafe" title="Delete user transition"/>
+  <descriptor id="UserList" type="semantic" title="User list state"/>
+  <descriptor id="User" type="semantic" title="User detail state"/>
+  <descriptor id="goUserList" type="safe" title="Open user list transition" rt="#UserList"/>
+  <descriptor id="doSyncUser" type="idempotent" title="Synchronize user transition" rt="#User"/>
+  <descriptor id="doDeleteUser" type="idempotent" title="Delete user transition" rt="#UserList"/>
+  <descriptor id="doCreateUser" type="unsafe" title="Create user transition" rt="#User"/>
   <descriptor id="userIdAlias" type="semantic" href="#userId"/>
   <descriptor id="danglingHref" type="semantic" href="#nonExistent"/>
   <descriptor id="chainA" type="semantic" href="#chainB"/>

--- a/tests/Fake/alps-profile.xml
+++ b/tests/Fake/alps-profile.xml
@@ -12,6 +12,8 @@
     </descriptor>
   </descriptor>
   <descriptor id="createUser" type="safe" title="Create user transition"/>
+  <descriptor id="syncUser" type="idempotent" title="Synchronize user transition"/>
+  <descriptor id="deleteUser" type="unsafe" title="Delete user transition"/>
   <descriptor id="userIdAlias" type="semantic" href="#userId"/>
   <descriptor id="danglingHref" type="semantic" href="#nonExistent"/>
   <descriptor id="chainA" type="semantic" href="#chainB"/>

--- a/tests/Runtime/AgentOptionsTest.php
+++ b/tests/Runtime/AgentOptionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AgentOptions::class)]
+final class AgentOptionsTest extends TestCase
+{
+    public function testNullEnabledToolsDoesNotFilter(): void
+    {
+        $tools = [
+            $this->tool('article_get'),
+            $this->tool('article_post'),
+        ];
+
+        $options = new AgentOptions();
+
+        $this->assertSame($tools, $options->filterTools($tools));
+        $this->assertFalse($options->filtersTools());
+    }
+
+    public function testWithToolsFiltersInOriginalToolOrder(): void
+    {
+        $tools = [
+            $this->tool('article_get'),
+            $this->tool('article_post'),
+            $this->tool('article_delete'),
+        ];
+
+        $options = AgentOptions::withTools(['article_delete', 'article_get']);
+
+        $filtered = $options->filterTools($tools);
+
+        $this->assertTrue($options->filtersTools());
+        $this->assertSame(['article_get', 'article_delete'], [
+            $filtered[0]->name,
+            $filtered[1]->name,
+        ]);
+    }
+
+    public function testEmptyEnabledToolsFiltersAllTools(): void
+    {
+        $options = AgentOptions::withTools([]);
+
+        $this->assertSame([], $options->filterTools([$this->tool('article_get')]));
+        $this->assertTrue($options->filtersTools());
+    }
+
+    public function testUnknownToolThrows(): void
+    {
+        $options = AgentOptions::withTools(['missing_tool']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown tool(s): missing_tool');
+
+        $options->filterTools([$this->tool('article_get')]);
+    }
+
+    private function tool(string $name): Tool
+    {
+        return new Tool($name, 'Test tool', [
+            'type' => 'object',
+            'properties' => [],
+            'required' => [],
+        ]);
+    }
+}

--- a/tests/Runtime/AgentPoolTest.php
+++ b/tests/Runtime/AgentPoolTest.php
@@ -28,6 +28,8 @@ use function array_map;
 #[CoversClass(AgentPool::class)]
 #[CoversClass(AgentDelegator::class)]
 #[CoversClass(AgentFactory::class)]
+#[CoversClass(DenyConfirmationHandler::class)]
+#[CoversClass(ProfiledAgent::class)]
 final class AgentPoolTest extends TestCase
 {
     public function testRegisterAndGetProfile(): void
@@ -205,6 +207,23 @@ final class AgentPoolTest extends TestCase
         $this->assertSame('Unknown agent: missing', $result->content);
     }
 
+    public function testDelegatorFallsBackForUnknownAskTool(): void
+    {
+        [$pool] = $this->createPool();
+        $fallback = new class implements DispatcherInterface {
+            public function dispatch(ToolCall $toolCall): ToolResult
+            {
+                return ToolResult::success($toolCall->id, 'fallback ask result');
+            }
+        };
+        $delegator = new AgentDelegator($pool, $fallback);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_custom', ['message' => 'Hi']));
+
+        $this->assertFalse($result->isError);
+        $this->assertSame('fallback ask result', $result->content);
+    }
+
     public function testDelegatorReturnsErrorForInvalidToolInput(): void
     {
         [$pool] = $this->createPool();
@@ -264,6 +283,73 @@ final class AgentPoolTest extends TestCase
         $this->assertSame('Subagent stopped: max_tokens', $result->content);
     }
 
+    public function testDelegatorConvertsSubagentExceptionToToolError(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+            resources: ['app://self/article'],
+            options: AgentOptions::withTools(['missing_tool']),
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', ['message' => 'Review this.']));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('InvalidArgumentException: Unknown tool(s): missing_tool', $result->content);
+    }
+
+    public function testPoolCreateAppliesProfileOptions(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+            resources: ['app://self/article', 'app://self/error'],
+            options: AgentOptions::withTools(['article_get']),
+        ));
+
+        $agent = $pool->create('critic');
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        $llmClient->queueTextResponse('Rejected.');
+
+        $response = $agent->run('Try hidden tool.');
+
+        $this->assertTrue($response->completed);
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testProfiledAgentResetDelegatesToInnerAgent(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+
+        $agent = $pool->create('critic');
+        $llmClient->queueTextResponse('Done.');
+        $agent->run('Review this.');
+        $agent->reset();
+        $llmClient->queueTextResponse('Again.');
+        $agent->run('Review again.');
+
+        $this->assertCount(1, $llmClient->calls[1]['messages']);
+    }
+
+    public function testDenyConfirmationHandlerDeniesEveryCall(): void
+    {
+        $handler = new DenyConfirmationHandler();
+
+        $this->assertFalse($handler->confirm(new ToolCall('call_1', 'dangerous_tool', []), 'Confirm?'));
+    }
+
     public function testMainAgentCanCallSubagentAsTool(): void
     {
         [$pool, $llmClient, $resourceDispatcher] = $this->createPool();
@@ -306,6 +392,29 @@ final class AgentPoolTest extends TestCase
         $factory->addSubagents($pool);
 
         $this->assertSame('ask_critic', $factory->getTools()[0]->name);
+    }
+
+    public function testAgentFactoryWiresSubagentDispatcher(): void
+    {
+        [$pool, $llmClient, $resourceDispatcher, $collector, $registry] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+
+        $factory = new AgentFactory($llmClient, $resourceDispatcher, $collector, $registry);
+        $factory->addSubagents($pool);
+
+        $llmClient->queueToolUseResponse('call_1', 'ask_critic', ['message' => 'Review this.']);
+        $llmClient->queueTextResponse('Risk found.');
+        $llmClient->queueTextResponse('Delegation complete.');
+
+        $agent = $factory->create('You are a main agent.');
+        $response = $agent->run('Use critic.');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Risk found.', $llmClient->calls[2]['messages'][2]->content[0]['content']);
     }
 
     /** @return array{AgentPool, FakeLlmClient, Dispatcher, ToolCollector, ToolRegistry} */

--- a/tests/Runtime/AgentPoolTest.php
+++ b/tests/Runtime/AgentPoolTest.php
@@ -8,9 +8,11 @@ use BEAR\Resource\FactoryInterface;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\DispatcherInterface;
 use BEAR\ToolUse\Dispatch\NullToolCallObserver;
 use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Schema\SchemaConverter;
 use BEAR\ToolUse\Schema\ToolCollector;
@@ -25,6 +27,7 @@ use function array_map;
 #[CoversClass(AgentProfile::class)]
 #[CoversClass(AgentPool::class)]
 #[CoversClass(AgentDelegator::class)]
+#[CoversClass(AgentFactory::class)]
 final class AgentPoolTest extends TestCase
 {
     public function testRegisterAndGetProfile(): void
@@ -148,6 +151,60 @@ final class AgentPoolTest extends TestCase
         $this->assertSame("Review this.\n\nContext:\n{\"id\":1}", $llmClient->calls[0]['messages'][0]->content[0]['text']);
     }
 
+    public function testDelegatorCanDispatchKnownSubagentToolOnly(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $this->assertFalse($delegator->canDispatch('article_get'));
+        $this->assertTrue($delegator->canDispatch('ask_critic'));
+        $this->assertFalse($delegator->canDispatch('ask_missing'));
+    }
+
+    public function testDelegatorFallsBackForNonAgentTool(): void
+    {
+        [$pool] = $this->createPool();
+        $fallback = new class implements DispatcherInterface {
+            public function dispatch(ToolCall $toolCall): ToolResult
+            {
+                return ToolResult::success($toolCall->id, 'fallback result');
+            }
+        };
+        $delegator = new AgentDelegator($pool, $fallback);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'article_get', []));
+
+        $this->assertFalse($result->isError);
+        $this->assertSame('fallback result', $result->content);
+    }
+
+    public function testDelegatorReturnsUnknownToolWithoutFallback(): void
+    {
+        [$pool] = $this->createPool();
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'article_get', []));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Unknown tool: article_get', $result->content);
+    }
+
+    public function testDelegatorReturnsUnknownAgentForAskTool(): void
+    {
+        [$pool] = $this->createPool();
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_missing', ['message' => 'Hi']));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Unknown agent: missing', $result->content);
+    }
+
     public function testDelegatorReturnsErrorForInvalidToolInput(): void
     {
         [$pool] = $this->createPool();
@@ -162,6 +219,49 @@ final class AgentPoolTest extends TestCase
 
         $this->assertTrue($result->isError);
         $this->assertSame('Agent tool input "message" must be a string.', $result->content);
+    }
+
+    public function testDelegatorReturnsErrorForInvalidContextInput(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $stringContext = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', [
+            'message' => 'Review this.',
+            'context' => 'invalid',
+        ]));
+        $listContext = $delegator->dispatch(new ToolCall('call_2', 'ask_critic', [
+            'message' => 'Review this.',
+            'context' => ['invalid'],
+        ]));
+
+        $this->assertTrue($stringContext->isError);
+        $this->assertSame('Agent tool input "context" must be an object.', $stringContext->content);
+        $this->assertTrue($listContext->isError);
+        $this->assertSame('Agent tool input "context" must be an object.', $listContext->content);
+    }
+
+    public function testDelegatorReturnsErrorWhenSubagentDoesNotComplete(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueMaxTokensResponse('Partial.');
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', ['message' => 'Review this.']));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Subagent stopped: max_tokens', $result->content);
     }
 
     public function testMainAgentCanCallSubagentAsTool(): void

--- a/tests/Runtime/AgentPoolTest.php
+++ b/tests/Runtime/AgentPoolTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\Resource\FactoryInterface;
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolCall;
+use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeLlmClient;
+use BEAR\ToolUse\Schema\SchemaConverter;
+use BEAR\ToolUse\Schema\ToolCollector;
+use InvalidArgumentException;
+use phpDocumentor\Reflection\DocBlockFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+use function array_map;
+
+#[CoversClass(AgentProfile::class)]
+#[CoversClass(AgentPool::class)]
+#[CoversClass(AgentDelegator::class)]
+final class AgentPoolTest extends TestCase
+{
+    public function testRegisterAndGetProfile(): void
+    {
+        [$pool] = $this->createPool();
+        $profile = new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        );
+
+        $pool->register($profile);
+
+        $this->assertTrue($pool->has('critic'));
+        $this->assertSame($profile, $pool->get('critic'));
+    }
+
+    public function testUnknownAgentThrows(): void
+    {
+        [$pool] = $this->createPool();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown agent: missing');
+
+        $pool->get('missing');
+    }
+
+    public function testInvalidProfileNameThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid agent name: ask-critic');
+
+        new AgentProfile(
+            name: 'ask-critic',
+            description: 'Invalid',
+            systemPrompt: 'Invalid',
+        );
+    }
+
+    public function testProfileCreatesToolDefinition(): void
+    {
+        $profile = new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        );
+
+        $tool = $profile->toTool();
+
+        $this->assertSame('ask_critic', $tool->name);
+        $this->assertSame('Review design risks', $tool->description);
+        $this->assertSame(['message'], $tool->inputSchema['required']);
+    }
+
+    public function testDelegatorAskUsesProfileResources(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+            resources: ['app://self/article'],
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueTextResponse('Risk found.');
+
+        $response = $delegator->ask('critic', 'Review this.');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Risk found.', $response->getText());
+        $this->assertSame('You are a critic.', $llmClient->calls[0]['system']);
+        $this->assertSame(['article_get'], array_map(
+            static fn ($tool): string => $tool->name,
+            $llmClient->calls[0]['tools'],
+        ));
+    }
+
+    public function testDelegatorAskIsolatesSubagentHistoryPerCall(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueTextResponse('First.');
+        $llmClient->queueTextResponse('Second.');
+
+        $delegator->ask('critic', 'First task.');
+        $delegator->ask('critic', 'Second task.');
+
+        $this->assertCount(1, $llmClient->calls[0]['messages']);
+        $this->assertCount(1, $llmClient->calls[1]['messages']);
+        $this->assertSame('First task.', $llmClient->calls[0]['messages'][0]->content[0]['text']);
+        $this->assertSame('Second task.', $llmClient->calls[1]['messages'][0]->content[0]['text']);
+    }
+
+    public function testDelegatorDispatchesSubagentToolCall(): void
+    {
+        [$pool, $llmClient] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $llmClient->queueTextResponse('Risk found.');
+
+        $result = $delegator->dispatch(new ToolCall(
+            id: 'call_1',
+            name: 'ask_critic',
+            input: ['message' => 'Review this.', 'context' => ['id' => 1]],
+        ));
+
+        $this->assertFalse($result->isError);
+        $this->assertSame('Risk found.', $result->content);
+        $this->assertSame("Review this.\n\nContext:\n{\"id\":1}", $llmClient->calls[0]['messages'][0]->content[0]['text']);
+    }
+
+    public function testDelegatorReturnsErrorForInvalidToolInput(): void
+    {
+        [$pool] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $delegator = new AgentDelegator($pool);
+
+        $result = $delegator->dispatch(new ToolCall('call_1', 'ask_critic', []));
+
+        $this->assertTrue($result->isError);
+        $this->assertSame('Agent tool input "message" must be a string.', $result->content);
+    }
+
+    public function testMainAgentCanCallSubagentAsTool(): void
+    {
+        [$pool, $llmClient, $resourceDispatcher] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+        $mainAgent = new Agent(
+            client: $llmClient,
+            dispatcher: new AgentDelegator($pool, $resourceDispatcher),
+            tools: $pool->getTools(),
+            systemPrompt: 'You are a main agent.',
+            maxIterations: 5,
+        );
+
+        $llmClient->queueToolUseResponse('call_1', 'ask_critic', ['message' => 'Review this.']);
+        $llmClient->queueTextResponse('Risk found.');
+        $llmClient->queueTextResponse('Delegation complete.');
+
+        $response = $mainAgent->run('Use critic.');
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('Delegation complete.', $response->getText());
+        $this->assertSame('You are a main agent.', $llmClient->calls[0]['system']);
+        $this->assertSame('You are a critic.', $llmClient->calls[1]['system']);
+        $this->assertSame('Risk found.', $llmClient->calls[2]['messages'][2]->content[0]['content']);
+    }
+
+    public function testAgentFactoryAddsSubagentTools(): void
+    {
+        [$pool, $llmClient, $resourceDispatcher, $collector, $registry] = $this->createPool();
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+        ));
+
+        $factory = new AgentFactory($llmClient, $resourceDispatcher, $collector, $registry);
+        $factory->addSubagents($pool);
+
+        $this->assertSame('ask_critic', $factory->getTools()[0]->name);
+    }
+
+    /** @return array{AgentPool, FakeLlmClient, Dispatcher, ToolCollector, ToolRegistry} */
+    private function createPool(): array
+    {
+        $llmClient = new FakeLlmClient();
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $resourceFactory = $injector->getInstance(FactoryInterface::class);
+        $registry = new ToolRegistry();
+        $converter = new SchemaConverter(DocBlockFactory::createInstance());
+        $collector = new ToolCollector($converter, $registry, $resourceFactory);
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
+        $pool = new AgentPool($llmClient, $dispatcher, $collector);
+
+        return [$pool, $llmClient, $dispatcher, $collector, $registry];
+    }
+}

--- a/tests/Runtime/AgentPoolTest.php
+++ b/tests/Runtime/AgentPoolTest.php
@@ -15,8 +15,11 @@ use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Schema\SchemaConverter;
+use BEAR\ToolUse\Schema\Tool;
 use BEAR\ToolUse\Schema\ToolCollector;
+use BEAR\ToolUse\Schema\ToolCollectorInterface;
 use InvalidArgumentException;
+use Override;
 use phpDocumentor\Reflection\DocBlockFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -82,6 +85,7 @@ final class AgentPoolTest extends TestCase
         $this->assertSame('ask_critic', $tool->name);
         $this->assertSame('Review design risks', $tool->description);
         $this->assertSame(['message'], $tool->inputSchema['required']);
+        $this->assertTrue($tool->inputSchema['properties']['context']['additionalProperties']);
     }
 
     public function testDelegatorAskUsesProfileResources(): void
@@ -150,7 +154,7 @@ final class AgentPoolTest extends TestCase
 
         $this->assertFalse($result->isError);
         $this->assertSame('Risk found.', $result->content);
-        $this->assertSame("Review this.\n\nContext:\n{\"id\":1}", $llmClient->calls[0]['messages'][0]->content[0]['text']);
+        $this->assertSame("Review this.\n\n<context>\n{\"id\":1}\n</context>", $llmClient->calls[0]['messages'][0]->content[0]['text']);
     }
 
     public function testDelegatorCanDispatchKnownSubagentToolOnly(): void
@@ -322,6 +326,52 @@ final class AgentPoolTest extends TestCase
         $toolResultMessage = $llmClient->calls[1]['messages'][2];
         $this->assertTrue($toolResultMessage->content[0]['is_error']);
         $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testPoolCachesCollectedToolsPerProfile(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $dispatcher = new class implements DispatcherInterface {
+            #[Override]
+            public function dispatch(ToolCall $toolCall): ToolResult
+            {
+                return ToolResult::success($toolCall->id, 'unused');
+            }
+        };
+        $collector = new class implements ToolCollectorInterface {
+            public int $calls = 0;
+
+            /**
+             * @param list<string> $uris
+             *
+             * @return list<Tool>
+             */
+            #[Override]
+            public function collect(array $uris): array
+            {
+                $this->calls++;
+
+                return [
+                    new Tool('cached_get', 'Cached tool', [
+                        'type' => 'object',
+                        'properties' => [],
+                        'required' => [],
+                    ]),
+                ];
+            }
+        };
+        $pool = new AgentPool($llmClient, $dispatcher, $collector);
+        $pool->register(new AgentProfile(
+            name: 'critic',
+            description: 'Review design risks',
+            systemPrompt: 'You are a critic.',
+            resources: ['app://self/cached'],
+        ));
+
+        $pool->create('critic');
+        $pool->create('critic');
+
+        $this->assertSame(1, $collector->calls);
     }
 
     public function testProfiledAgentResetDelegatesToInnerAgent(): void

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\ToolUse\Dispatch\Dispatcher;
+use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolRegistry;
+use BEAR\ToolUse\Fake\FakeInputProcessor;
+use BEAR\ToolUse\Fake\FakeLlmClient;
+use BEAR\ToolUse\Fake\FakeOutputProcessor;
+use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
+use BEAR\ToolUse\Fake\FakeToolFilteringInputProcessor;
+use BEAR\ToolUse\Llm\StreamEvent;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+use function iterator_to_array;
+
+#[CoversClass(Agent::class)]
+#[CoversClass(StreamingAgent::class)]
+#[CoversClass(AgentOptions::class)]
+#[CoversClass(LlmRequest::class)]
+final class AgentProcessorTest extends TestCase
+{
+    public function testInputProcessorChangesAgentRequest(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new FakeInputProcessor(' Use memory.', 'remember user context');
+
+        $llmClient->queueTextResponse('Done.');
+
+        $agent->run('Hello', AgentOptions::withProcessors(inputProcessors: [$processor]));
+
+        $this->assertSame(1, $processor->calls);
+        $this->assertSame('You are a helpful assistant. Use memory.', $llmClient->calls[0]['system']);
+        $this->assertSame('remember user context', $llmClient->calls[0]['messages'][1]->content[0]['text']);
+    }
+
+    public function testOutputProcessorChangesAgentResponse(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new FakeOutputProcessor('Processed response.');
+
+        $llmClient->queueTextResponse('Raw response.');
+
+        $response = $agent->run('Hello', AgentOptions::withProcessors(outputProcessors: [$processor]));
+
+        $this->assertSame(1, $processor->calls);
+        $this->assertSame('Processed response.', $response->getText());
+    }
+
+    public function testProcessorsRunOnEveryToolLoopIteration(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $inputProcessor = new FakeInputProcessor(memoryText: 'memory');
+        $outputProcessor = new FakeOutputProcessor('processed');
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+        $llmClient->queueTextResponse('Done.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(
+            inputProcessors: [$inputProcessor],
+            outputProcessors: [$outputProcessor],
+        ));
+
+        $this->assertSame(2, $inputProcessor->calls);
+        $this->assertSame(2, $outputProcessor->calls);
+        $this->assertSame('memory', $llmClient->calls[1]['messages'][3]->content[0]['text']);
+    }
+
+    public function testInputProcessorFilteredToolIsEnforced(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        $llmClient->queueTextResponse('Recovered.');
+
+        $agent->run('Try error tool', AgentOptions::withProcessors(
+            inputProcessors: [new FakeToolFilteringInputProcessor('article_get')],
+        ));
+
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testStreamingProcessorsAreApplied(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgent($llmClient);
+        $inputProcessor = new FakeInputProcessor(' Stream.', 'stream memory');
+        $outputProcessor = new FakeOutputProcessor('Processed');
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Raw']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($agent->runStream('Hi', AgentOptions::withProcessors(
+            inputProcessors: [$inputProcessor],
+            outputProcessors: [$outputProcessor],
+        )));
+
+        $this->assertSame(1, $inputProcessor->calls);
+        $this->assertSame(3, $outputProcessor->calls);
+        $this->assertSame('You are a helpful assistant. Stream.', $llmClient->calls[0]['system']);
+        $this->assertSame('stream memory', $llmClient->calls[0]['messages'][1]->content[0]['text']);
+        $this->assertSame('Processed', $events[0]->data['text']);
+        $this->assertSame('Processed', $events[1]->data['fullText']);
+    }
+
+    private function createAgent(FakeLlmClient $llmClient): Agent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [$this->articleTool()],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    private function createStreamingAgent(FakeStreamingLlmClient $llmClient): StreamingAgent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+
+        return new StreamingAgent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [$this->articleTool()],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    private function createAgentWithArticleAndErrorTools(FakeLlmClient $llmClient): Agent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [
+                $this->articleTool(),
+                new Tool('error_get', 'Get error resource', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    /** @return array{ResourceInterface, ToolRegistry} */
+    private function resourceAndRegistry(): array
+    {
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+
+        return [
+            $injector->getInstance(ResourceInterface::class),
+            new ToolRegistry(),
+        ];
+    }
+
+    private function articleTool(): Tool
+    {
+        return new Tool('article_get', 'Get an article', [
+            'type' => 'object',
+            'properties' => ['id' => ['type' => 'integer']],
+            'required' => ['id'],
+        ]);
+    }
+}

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -100,6 +100,67 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame('memory', $llmClient->calls[1]['messages'][3]->content[0]['text']);
     }
 
+    public function testAgentOutputProcessorMustPreserveToolUseContentBlocks(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if (! $output instanceof LlmResponse) {
+                    return $output;
+                }
+
+                return new LlmResponse(
+                    $output->stopReason,
+                    [['type' => 'text', 'text' => 'corrupted']],
+                    $output->toolCalls,
+                );
+            }
+        };
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve tool_use content blocks for tool calls.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
+    }
+
+    public function testAgentOutputProcessorMustPreserveToolUseNameAndInput(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if (! $output instanceof LlmResponse) {
+                    return $output;
+                }
+
+                $content = [];
+                foreach ($output->content as $block) {
+                    if (($block['type'] ?? null) === 'tool_use') {
+                        $block['name'] = 'other_get';
+                    }
+
+                    $content[] = $block;
+                }
+
+                return new LlmResponse($output->stopReason, $content, $output->toolCalls);
+            }
+        };
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve tool_use content blocks for tool calls.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
+    }
+
     public function testInputProcessorFilteredToolIsEnforced(): void
     {
         $llmClient = new FakeLlmClient();
@@ -112,6 +173,22 @@ final class AgentProcessorTest extends TestCase
             inputProcessors: [new FakeToolFilteringInputProcessor('article_get')],
         ));
 
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
+    }
+
+    public function testAgentRejectsUnadvertisedRegisteredToolWithoutOptions(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleToolAndErrorRegistry($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        $llmClient->queueTextResponse('Recovered.');
+
+        $response = $agent->run('Try hidden error tool');
+
+        $this->assertTrue($response->completed);
         $toolResultMessage = $llmClient->calls[1]['messages'][2];
         $this->assertTrue($toolResultMessage->content[0]['is_error']);
         $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
@@ -146,6 +223,31 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame('Processed', $events[1]->data['fullText']);
     }
 
+    public function testStreamingAgentRejectsUnadvertisedRegisteredToolWithoutOptions(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleToolAndErrorRegistry($llmClient);
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'error_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => '{}']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Recovered.']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($agent->runStream('Try hidden error tool'));
+
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
+    }
+
     public function testStreamingOutputProcessorMustReturnStreamEvent(): void
     {
         $llmClient = new FakeStreamingLlmClient();
@@ -170,6 +272,68 @@ final class AgentProcessorTest extends TestCase
         $this->expectExceptionMessage('Output processor must return StreamEvent for streaming calls.');
 
         iterator_to_array($agent->runStream('Hi', AgentOptions::withProcessors(outputProcessors: [$processor])));
+    }
+
+    public function testStreamingOutputProcessorMustPreserveStreamEventType(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if ($output instanceof StreamEvent && $output->type === StreamEvent::TOOL_USE_START) {
+                    return new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'corrupted']);
+                }
+
+                return $output;
+            }
+        };
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'article_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => '{"id":1}']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+        ]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve stream event type.');
+
+        iterator_to_array($agent->runStream('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor])));
+    }
+
+    public function testStreamingOutputProcessorMustPreserveToolUseControlData(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if ($output instanceof StreamEvent && $output->type === StreamEvent::TOOL_USE_DELTA) {
+                    return new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => '{"id":2}']);
+                }
+
+                return $output;
+            }
+        };
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'article_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => '{"id":1}']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+        ]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve stream tool-use control data.');
+
+        iterator_to_array($agent->runStream('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor])));
     }
 
     private function createAgent(FakeLlmClient $llmClient): Agent
@@ -200,6 +364,21 @@ final class AgentProcessorTest extends TestCase
         );
     }
 
+    private function createStreamingAgentWithArticleToolAndErrorRegistry(FakeStreamingLlmClient $llmClient): StreamingAgent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+
+        return new StreamingAgent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [$this->articleTool()],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
     private function createAgentWithArticleAndErrorTools(FakeLlmClient $llmClient): Agent
     {
         [$resource, $registry] = $this->resourceAndRegistry();
@@ -217,6 +396,21 @@ final class AgentProcessorTest extends TestCase
                     'required' => [],
                 ]),
             ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
+    }
+
+    private function createAgentWithArticleToolAndErrorRegistry(FakeLlmClient $llmClient): Agent
+    {
+        [$resource, $registry] = $this->resourceAndRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: new Dispatcher($resource, $registry, new NullToolCallObserver()),
+            tools: [$this->articleTool()],
             systemPrompt: 'You are a helpful assistant.',
             maxIterations: 5,
         );

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -214,6 +214,30 @@ final class AgentProcessorTest extends TestCase
         $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
     }
 
+    public function testAgentOutputProcessorMustPreserveToolCallCount(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if (! $output instanceof LlmResponse) {
+                    return $output;
+                }
+
+                return new LlmResponse('tool_use', $output->content, []);
+            }
+        };
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve tool_use tool calls.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
+    }
+
     public function testInputProcessorFilteredToolIsEnforced(): void
     {
         $llmClient = new FakeLlmClient();

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -8,6 +8,7 @@ use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\ToolUse\Dispatch\Dispatcher;
 use BEAR\ToolUse\Dispatch\NullToolCallObserver;
+use BEAR\ToolUse\Dispatch\ToolCall;
 use BEAR\ToolUse\Dispatch\ToolRegistry;
 use BEAR\ToolUse\Fake\FakeInputProcessor;
 use BEAR\ToolUse\Fake\FakeLlmClient;
@@ -157,6 +158,58 @@ final class AgentProcessorTest extends TestCase
 
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Output processor must preserve tool_use content blocks for tool calls.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
+    }
+
+    public function testAgentOutputProcessorMustPreserveToolUseStopReason(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if (! $output instanceof LlmResponse) {
+                    return $output;
+                }
+
+                return new LlmResponse('end_turn', $output->content, $output->toolCalls);
+            }
+        };
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve tool_use stop reason.');
+
+        $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
+    }
+
+    public function testAgentOutputProcessorMustPreserveOriginalToolCalls(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                if (! $output instanceof LlmResponse) {
+                    return $output;
+                }
+
+                return new LlmResponse(
+                    'tool_use',
+                    [['type' => 'tool_use', 'id' => 'call_2', 'name' => 'other_get', 'input' => ['id' => 2]]],
+                    [new ToolCall('call_2', 'other_get', ['id' => 2])],
+                );
+            }
+        };
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must preserve tool_use tool calls.');
 
         $agent->run('Use tool', AgentOptions::withProcessors(outputProcessors: [$processor]));
     }

--- a/tests/Runtime/AgentProcessorTest.php
+++ b/tests/Runtime/AgentProcessorTest.php
@@ -14,11 +14,14 @@ use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Fake\FakeOutputProcessor;
 use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Fake\FakeToolFilteringInputProcessor;
+use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Schema\Tool;
+use Override;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
+use UnexpectedValueException;
 
 use function iterator_to_array;
 
@@ -55,6 +58,26 @@ final class AgentProcessorTest extends TestCase
 
         $this->assertSame(1, $processor->calls);
         $this->assertSame('Processed response.', $response->getText());
+    }
+
+    public function testAgentOutputProcessorMustReturnLlmResponse(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                return new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'wrong type']);
+            }
+        };
+
+        $llmClient->queueTextResponse('Raw response.');
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must return LlmResponse for non-streaming calls.');
+
+        $agent->run('Hello', AgentOptions::withProcessors(outputProcessors: [$processor]));
     }
 
     public function testProcessorsRunOnEveryToolLoopIteration(): void
@@ -121,6 +144,32 @@ final class AgentProcessorTest extends TestCase
         $this->assertSame('stream memory', $llmClient->calls[0]['messages'][1]->content[0]['text']);
         $this->assertSame('Processed', $events[0]->data['text']);
         $this->assertSame('Processed', $events[1]->data['fullText']);
+    }
+
+    public function testStreamingOutputProcessorMustReturnStreamEvent(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgent($llmClient);
+        $processor = new class implements OutputProcessorInterface {
+            #[Override]
+            public function process(LlmResponse|StreamEvent $output, LlmRequest $request): LlmResponse|StreamEvent
+            {
+                return new LlmResponse('end_turn', [['type' => 'text', 'text' => 'wrong type']], []);
+            }
+        };
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Raw']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Output processor must return StreamEvent for streaming calls.');
+
+        iterator_to_array($agent->runStream('Hi', AgentOptions::withProcessors(outputProcessors: [$processor])));
     }
 
     private function createAgent(FakeLlmClient $llmClient): Agent

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -13,11 +13,15 @@ use BEAR\ToolUse\Dispatch\ToolResult;
 use BEAR\ToolUse\Fake\FakeLlmClient;
 use BEAR\ToolUse\Llm\LlmResponse;
 use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 
+use function array_map;
+
 #[CoversClass(Agent::class)]
+#[CoversClass(AgentOptions::class)]
 #[CoversClass(AgentResponse::class)]
 #[CoversClass(Message::class)]
 final class AgentTest extends TestCase
@@ -121,6 +125,65 @@ final class AgentTest extends TestCase
 
         $this->assertTrue($response->completed);
         $this->assertSame('I found the article!', $response->getText());
+    }
+
+    public function testRunWithToolFilteringPassesOnlyEnabledTools(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueTextResponse('Done.');
+
+        $response = $agent->run('Use limited tools', AgentOptions::withTools(['article_get']));
+
+        $this->assertTrue($response->completed);
+        $this->assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[0]['tools'],
+        ));
+    }
+
+    public function testRunWithToolFilteringPassesOnlyEnabledToolsAfterToolUse(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'article_get', ['id' => 1]);
+        $llmClient->queueTextResponse('Done.');
+
+        $response = $agent->run('Use limited tools', AgentOptions::withTools(['article_get']));
+
+        $this->assertTrue($response->completed);
+        $this->assertCount(2, $llmClient->calls);
+        $this->assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[1]['tools'],
+        ));
+    }
+
+    public function testRunWithUnknownToolFilterThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown tool(s): missing_tool');
+
+        $this->agent->run('Use missing tool', AgentOptions::withTools(['missing_tool']));
+    }
+
+    public function testRunWithDisabledToolCallReturnsErrorWithoutDispatching(): void
+    {
+        $llmClient = new FakeLlmClient();
+        $agent = $this->createAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->queueToolUseResponse('call_1', 'error_get', []);
+        $llmClient->queueTextResponse('The disabled tool was not used.');
+
+        $response = $agent->run('Try disabled tool', AgentOptions::withTools(['article_get']));
+
+        $this->assertTrue($response->completed);
+        $this->assertSame('The disabled tool was not used.', $response->getText());
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        $this->assertTrue($toolResultMessage->content[0]['is_error']);
+        $this->assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
     }
 
     public function testMessageUser(): void
@@ -429,5 +492,34 @@ final class AgentTest extends TestCase
         $this->assertTrue($toolResultMessage->content[0]['is_error']);
         $this->assertStringContainsString('400:', $toolResultMessage->content[0]['content']);
         $this->assertStringContainsString('Validation failed', $toolResultMessage->content[0]['content']);
+    }
+
+    private function createAgentWithArticleAndErrorTools(FakeLlmClient $llmClient): Agent
+    {
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
+
+        return new Agent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: [
+                new Tool('article_get', 'Get an article', [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id'],
+                ]),
+                new Tool('error_get', 'Get error resource', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
     }
 }

--- a/tests/Runtime/AgentTest.php
+++ b/tests/Runtime/AgentTest.php
@@ -64,6 +64,10 @@ final class AgentTest extends TestCase
 
         $this->assertTrue($response->completed);
         $this->assertSame('Hello! How can I help you?', $response->getText());
+        $this->assertCount(2, $this->agent->messages);
+        $this->assertSame('user', $this->agent->messages[0]->role);
+        $this->assertSame('assistant', $this->agent->messages[1]->role);
+        $this->assertSame($this->agent->messages, $response->messages);
     }
 
     public function testMaxIterationsReached(): void
@@ -89,6 +93,8 @@ final class AgentTest extends TestCase
         $this->assertFalse($response->completed);
         $this->assertSame(AgentResponse::STOP_MAX_TOKENS, $response->stopReason);
         $this->assertSame('This response was cut off...', $response->getText());
+        $this->assertCount(2, $response->messages);
+        $this->assertSame('assistant', $response->messages[1]->role);
     }
 
     public function testStopSequenceResponse(): void
@@ -99,6 +105,8 @@ final class AgentTest extends TestCase
 
         $this->assertFalse($response->completed);
         $this->assertSame(AgentResponse::STOP_STOP_SEQUENCE, $response->stopReason);
+        $this->assertCount(2, $response->messages);
+        $this->assertSame('assistant', $response->messages[1]->role);
     }
 
     public function testUnknownStopReasonTreatedAsCompleted(): void
@@ -112,6 +120,24 @@ final class AgentTest extends TestCase
         $response = $this->agent->run('Test unknown stop reason');
 
         $this->assertTrue($response->completed);
+        $this->assertCount(2, $response->messages);
+        $this->assertSame('assistant', $response->messages[1]->role);
+    }
+
+    public function testEmptyAssistantResponseIsNotRecorded(): void
+    {
+        $this->llmClient->queueResponse(new LlmResponse(
+            stopReason: 'end_turn',
+            content: [],
+            toolCalls: [],
+        ));
+
+        $response = $this->agent->run('Return nothing');
+
+        $this->assertTrue($response->completed);
+        $this->assertCount(1, $this->agent->messages);
+        $this->assertSame('user', $this->agent->messages[0]->role);
+        $this->assertSame($this->agent->messages, $response->messages);
     }
 
     public function testToolUseWithSuccessfulDispatch(): void
@@ -267,7 +293,7 @@ final class AgentTest extends TestCase
         $response = $this->agent->run('Follow up question');
 
         $this->assertTrue($response->completed);
-        $this->assertCount(3, $this->agent->messages); // 2 history + 1 new user
+        $this->assertCount(4, $this->agent->messages); // 2 history + new user + assistant response
     }
 
     public function testAgentResponseCompleted(): void
@@ -277,6 +303,18 @@ final class AgentTest extends TestCase
         $this->assertTrue($response->completed);
         $this->assertSame('Done', $response->getText());
         $this->assertEmpty($response->messages);
+    }
+
+    public function testAgentResponseCompletedWithMessages(): void
+    {
+        $messages = [
+            Message::user('test'),
+            Message::assistant([['type' => 'text', 'text' => 'Done']]),
+        ];
+        $response = AgentResponse::completed([['type' => 'text', 'text' => 'Done']], $messages);
+
+        $this->assertTrue($response->completed);
+        $this->assertSame($messages, $response->messages);
     }
 
     public function testAgentResponseMaxIterations(): void

--- a/tests/Runtime/AlpsContextInputProcessorTest.php
+++ b/tests/Runtime/AlpsContextInputProcessorTest.php
@@ -106,7 +106,7 @@ final class AlpsContextInputProcessorTest extends TestCase
             'system',
             [Message::user('Create the user')],
             [
-                new Tool('createUser', 'Create user', [
+                new Tool('goUserList', 'Open user list', [
                     'type' => 'object',
                     'properties' => [],
                     'required' => [],
@@ -117,7 +117,7 @@ final class AlpsContextInputProcessorTest extends TestCase
         $processed = $processor->process($request);
 
         $this->assertSame(
-            "Application semantics from ALPS:\n- createUser [safe]: Create user transition",
+            "Application semantics from ALPS:\n- goUserList [safe]: Open user list transition",
             $processed->messages[1]->content[0]['text'],
         );
     }
@@ -129,7 +129,7 @@ final class AlpsContextInputProcessorTest extends TestCase
             'system',
             [Message::user('Create the user')],
             [
-                new Tool('create_user', 'Create user', [
+                new Tool('go_user_list', 'Open user list', [
                     'type' => 'object',
                     'properties' => [],
                     'required' => [],
@@ -140,7 +140,7 @@ final class AlpsContextInputProcessorTest extends TestCase
         $processed = $processor->process($request);
 
         $this->assertSame(
-            "Application semantics from ALPS:\n- create_user [safe]: Create user transition",
+            "Application semantics from ALPS:\n- go_user_list [safe]: Open user list transition",
             $processed->messages[1]->content[0]['text'],
         );
     }

--- a/tests/Runtime/AlpsContextInputProcessorTest.php
+++ b/tests/Runtime/AlpsContextInputProcessorTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AlpsContextInputProcessor::class)]
+#[CoversClass(LlmRequest::class)]
+final class AlpsContextInputProcessorTest extends TestCase
+{
+    private AlpsSemanticDictionary $dictionary;
+
+    protected function setUp(): void
+    {
+        $this->dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
+    }
+
+    public function testAddsRelevantAlpsSemanticsForToolParameters(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Find the user')],
+            [
+                new Tool('user_get', 'Get user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'userId' => ['type' => 'integer'],
+                        'email' => ['type' => 'string'],
+                        'missing' => ['type' => 'string'],
+                    ],
+                    'required' => ['userId'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertNotSame($request, $processed);
+        $this->assertSame('system', $processed->systemPrompt);
+        $this->assertSame($request->tools, $processed->tools);
+        $this->assertCount(2, $processed->messages);
+        $this->assertSame(
+            "Application semantics from ALPS:\n- user_get.userId: User identifier",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testResolvesSnakeCaseParameterThroughCamelCaseAlpsId(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('user_post', 'Create user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'user_name' => ['type' => 'string'],
+                    ],
+                    'required' => ['user_name'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- user_post.user_name: Name of the user",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testAddsToolNameSemanticsWhenAvailable(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('userId', 'User identifier tool', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- userId: User identifier",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testAddsTransitionTypeForMatchingToolDescriptor(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('createUser', 'Create user', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- createUser [safe]: Create user transition",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testResolvesSnakeCaseToolThroughCamelCaseAlpsId(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Create the user')],
+            [
+                new Tool('create_user', 'Create user', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n- create_user [safe]: Create user transition",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testReturnsOriginalRequestWhenNoSemanticsMatch(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Call tool')],
+            [
+                new Tool('unknown_get', 'Unknown', [
+                    'type' => 'object',
+                    'properties' => [
+                        'unknown' => ['type' => 'string'],
+                    ],
+                    'required' => ['unknown'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame($request, $processed);
+    }
+
+    public function testCustomHeading(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary, 'ALPS context:');
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Find resource')],
+            [
+                new Tool('resource_get', 'Get resource', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "ALPS context:\n- resource_get.id: Resource identifier",
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+
+    public function testDuplicateSemanticLinesAreCollapsed(): void
+    {
+        $processor = new AlpsContextInputProcessor($this->dictionary);
+        $request = new LlmRequest(
+            'system',
+            [Message::user('Find users')],
+            [
+                new Tool('user_get', 'Get user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+                new Tool('user_search', 'Search user', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+                new Tool('user_get', 'Get user again', [
+                    'type' => 'object',
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                    ],
+                    'required' => ['id'],
+                ]),
+            ],
+        );
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            "Application semantics from ALPS:\n"
+            . "- user_get.id: Resource identifier\n"
+            . '- user_search.id: Resource identifier',
+            $processed->messages[1]->content[0]['text'],
+        );
+    }
+}

--- a/tests/Runtime/AlpsToolPolicyInputProcessorTest.php
+++ b/tests/Runtime/AlpsToolPolicyInputProcessorTest.php
@@ -20,13 +20,14 @@ final class AlpsToolPolicyInputProcessorTest extends TestCase
         $this->dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
     }
 
-    public function testSafeOnlyKeepsSafeAndIdempotentTools(): void
+    public function testSafeOnlyKeepsSafeTools(): void
     {
         $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
         $request = $this->request([
-            $this->tool('createUser'),
-            $this->tool('syncUser'),
-            $this->tool('deleteUser'),
+            $this->tool('goUserList'),
+            $this->tool('doSyncUser'),
+            $this->tool('doDeleteUser'),
+            $this->tool('doCreateUser'),
             $this->tool('unknownTool'),
         ]);
 
@@ -34,7 +35,25 @@ final class AlpsToolPolicyInputProcessorTest extends TestCase
 
         $this->assertNotSame($request, $processed);
         $this->assertSame(
-            ['createUser', 'syncUser'],
+            ['goUserList'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testSafeAndIdempotentKeepsSafeAndIdempotentTools(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeAndIdempotent($this->dictionary);
+        $request = $this->request([
+            $this->tool('goUserList'),
+            $this->tool('doSyncUser'),
+            $this->tool('doDeleteUser'),
+            $this->tool('doCreateUser'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['goUserList', 'doSyncUser', 'doDeleteUser'],
             $this->toolNames($processed),
         );
     }
@@ -43,15 +62,35 @@ final class AlpsToolPolicyInputProcessorTest extends TestCase
     {
         $processor = AlpsToolPolicyInputProcessor::safeOnlyAllowingUnknownTools($this->dictionary);
         $request = $this->request([
-            $this->tool('createUser'),
-            $this->tool('deleteUser'),
+            $this->tool('goUserList'),
+            $this->tool('doDeleteUser'),
+            $this->tool('doCreateUser'),
             $this->tool('unknownTool'),
         ]);
 
         $processed = $processor->process($request);
 
         $this->assertSame(
-            ['createUser', 'unknownTool'],
+            ['goUserList', 'unknownTool'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testSafeAndIdempotentCanAllowUnknownTools(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeAndIdempotentAllowingUnknownTools($this->dictionary);
+        $request = $this->request([
+            $this->tool('goUserList'),
+            $this->tool('doSyncUser'),
+            $this->tool('doDeleteUser'),
+            $this->tool('doCreateUser'),
+            $this->tool('unknownTool'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['goUserList', 'doSyncUser', 'doDeleteUser', 'unknownTool'],
             $this->toolNames($processed),
         );
     }
@@ -60,14 +99,15 @@ final class AlpsToolPolicyInputProcessorTest extends TestCase
     {
         $processor = new AlpsToolPolicyInputProcessor($this->dictionary, ['unsafe']);
         $request = $this->request([
-            $this->tool('createUser'),
-            $this->tool('deleteUser'),
+            $this->tool('goUserList'),
+            $this->tool('doDeleteUser'),
+            $this->tool('doCreateUser'),
         ]);
 
         $processed = $processor->process($request);
 
         $this->assertSame(
-            ['deleteUser'],
+            ['doCreateUser'],
             $this->toolNames($processed),
         );
     }
@@ -76,14 +116,14 @@ final class AlpsToolPolicyInputProcessorTest extends TestCase
     {
         $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
         $request = $this->request([
-            $this->tool('create_user'),
-            $this->tool('delete_user'),
+            $this->tool('go_user_list'),
+            $this->tool('do_delete_user'),
         ]);
 
         $processed = $processor->process($request);
 
         $this->assertSame(
-            ['create_user'],
+            ['go_user_list'],
             $this->toolNames($processed),
         );
     }
@@ -92,8 +132,7 @@ final class AlpsToolPolicyInputProcessorTest extends TestCase
     {
         $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
         $request = $this->request([
-            $this->tool('createUser'),
-            $this->tool('syncUser'),
+            $this->tool('goUserList'),
         ]);
 
         $processed = $processor->process($request);

--- a/tests/Runtime/AlpsToolPolicyInputProcessorTest.php
+++ b/tests/Runtime/AlpsToolPolicyInputProcessorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ToolUse\Runtime;
+
+use BEAR\ToolUse\Schema\AlpsSemanticDictionary;
+use BEAR\ToolUse\Schema\Tool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AlpsToolPolicyInputProcessor::class)]
+#[CoversClass(LlmRequest::class)]
+final class AlpsToolPolicyInputProcessorTest extends TestCase
+{
+    private AlpsSemanticDictionary $dictionary;
+
+    protected function setUp(): void
+    {
+        $this->dictionary = new AlpsSemanticDictionary(__DIR__ . '/../Fake/alps-profile.json');
+    }
+
+    public function testSafeOnlyKeepsSafeAndIdempotentTools(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('syncUser'),
+            $this->tool('deleteUser'),
+            $this->tool('unknownTool'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertNotSame($request, $processed);
+        $this->assertSame(
+            ['createUser', 'syncUser'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testSafeOnlyCanAllowUnknownTools(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnlyAllowingUnknownTools($this->dictionary);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('deleteUser'),
+            $this->tool('unknownTool'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['createUser', 'unknownTool'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testCustomAllowedTypes(): void
+    {
+        $processor = new AlpsToolPolicyInputProcessor($this->dictionary, ['unsafe']);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('deleteUser'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['deleteUser'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testResolvesSnakeCaseToolThroughCamelCaseAlpsId(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
+        $request = $this->request([
+            $this->tool('create_user'),
+            $this->tool('delete_user'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame(
+            ['create_user'],
+            $this->toolNames($processed),
+        );
+    }
+
+    public function testReturnsOriginalRequestWhenNoToolIsFiltered(): void
+    {
+        $processor = AlpsToolPolicyInputProcessor::safeOnly($this->dictionary);
+        $request = $this->request([
+            $this->tool('createUser'),
+            $this->tool('syncUser'),
+        ]);
+
+        $processed = $processor->process($request);
+
+        $this->assertSame($request, $processed);
+    }
+
+    /** @param list<Tool> $tools */
+    private function request(array $tools): LlmRequest
+    {
+        return new LlmRequest('system', [Message::user('Run tools')], $tools);
+    }
+
+    private function tool(string $name): Tool
+    {
+        return new Tool($name, 'Tool ' . $name, [
+            'type' => 'object',
+            'properties' => [],
+            'required' => [],
+        ]);
+    }
+
+    /** @return list<string> */
+    private function toolNames(LlmRequest $request): array
+    {
+        $names = [];
+        foreach ($request->tools as $tool) {
+            $names[] = $tool->name;
+        }
+
+        return $names;
+    }
+}

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -13,6 +13,7 @@ use BEAR\ToolUse\Fake\FakeStreamingLlmClient;
 use BEAR\ToolUse\Fake\FakeThrowingDispatcher;
 use BEAR\ToolUse\Llm\StreamEvent;
 use BEAR\ToolUse\Schema\Tool;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -23,6 +24,7 @@ use function iterator_to_array;
 use function json_encode;
 
 #[CoversClass(StreamingAgent::class)]
+#[CoversClass(AgentOptions::class)]
 #[CoversClass(StreamContentAccumulator::class)]
 #[CoversClass(StreamIterationState::class)]
 #[CoversClass(AgentEvent::class)]
@@ -122,6 +124,94 @@ final class StreamingAgentTest extends TestCase
         self::assertSame('article_get', $events[1]->data['toolName']);
         self::assertSame('article_get', $events[2]->data['toolName']);
         self::assertSame("Looking up...\nFound it!", $events[5]->data['fullText']);
+    }
+
+    public function testRunStreamWithToolFilteringPassesOnlyEnabledTools(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleAndErrorTools($llmClient);
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Done']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($agent->runStream('Use limited tools', AgentOptions::withTools(['article_get'])));
+
+        self::assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[0]['tools'],
+        ));
+    }
+
+    public function testRunStreamWithToolFilteringPassesOnlyEnabledToolsAfterToolUse(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleAndErrorTools($llmClient);
+        $toolInput = json_encode(['id' => 1]);
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'article_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'Done']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        iterator_to_array($agent->runStream('Use limited tools', AgentOptions::withTools(['article_get'])));
+
+        self::assertCount(2, $llmClient->calls);
+        self::assertSame(['article_get'], array_map(
+            static fn (Tool $tool): string => $tool->name,
+            $llmClient->calls[1]['tools'],
+        ));
+    }
+
+    public function testRunStreamWithUnknownToolFilterThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown tool(s): missing_tool');
+
+        iterator_to_array($this->agent->runStream('Use missing tool', AgentOptions::withTools(['missing_tool'])));
+    }
+
+    public function testRunStreamWithDisabledToolCallReturnsErrorWithoutDispatching(): void
+    {
+        $llmClient = new FakeStreamingLlmClient();
+        $agent = $this->createStreamingAgentWithArticleAndErrorTools($llmClient);
+        $toolInput = json_encode([]);
+
+        $llmClient->setEventSequences([
+            [
+                new StreamEvent(StreamEvent::TOOL_USE_START, ['id' => 'call_1', 'name' => 'error_get']),
+                new StreamEvent(StreamEvent::TOOL_USE_DELTA, ['input' => $toolInput]),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'tool_use']),
+            ],
+            [
+                new StreamEvent(StreamEvent::TEXT_DELTA, ['text' => 'The disabled tool was not used.']),
+                new StreamEvent(StreamEvent::CONTENT_BLOCK_STOP),
+                new StreamEvent(StreamEvent::MESSAGE_STOP, ['stopReason' => 'end_turn']),
+            ],
+        ]);
+
+        /** @var list<AgentEvent> $events */
+        $events = iterator_to_array($agent->runStream('Try disabled tool', AgentOptions::withTools(['article_get'])));
+
+        $types = array_map(static fn (AgentEvent $e): string => $e->type, $events);
+        self::assertContains(AgentEvent::TOOL_RESULT, $types);
+        $toolResultMessage = $llmClient->calls[1]['messages'][2];
+        self::assertTrue($toolResultMessage->content[0]['is_error']);
+        self::assertSame('Tool is not enabled: error_get', $toolResultMessage->content[0]['content']);
     }
 
     public function testMaxIterationsReached(): void
@@ -314,5 +404,34 @@ final class StreamingAgentTest extends TestCase
         self::assertCount(2, $this->agent->messages);
         self::assertSame('user', $this->agent->messages[0]->role);
         self::assertSame('assistant', $this->agent->messages[1]->role);
+    }
+
+    private function createStreamingAgentWithArticleAndErrorTools(FakeStreamingLlmClient $llmClient): StreamingAgent
+    {
+        $injector = new Injector(new ResourceModule('BEAR\ToolUse\Fake'));
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $registry = new ToolRegistry();
+        $registry->register('article_get', 'app://self/article', 'get');
+        $registry->register('error_get', 'app://self/error', 'get');
+        $dispatcher = new Dispatcher($resource, $registry, new NullToolCallObserver());
+
+        return new StreamingAgent(
+            client: $llmClient,
+            dispatcher: $dispatcher,
+            tools: [
+                new Tool('article_get', 'Get an article', [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id'],
+                ]),
+                new Tool('error_get', 'Get error resource', [
+                    'type' => 'object',
+                    'properties' => [],
+                    'required' => [],
+                ]),
+            ],
+            systemPrompt: 'You are a helpful assistant.',
+            maxIterations: 5,
+        );
     }
 }

--- a/tests/Runtime/StreamingAgentTest.php
+++ b/tests/Runtime/StreamingAgentTest.php
@@ -294,6 +294,9 @@ final class StreamingAgentTest extends TestCase
         $lastEvent = end($events);
         self::assertSame(AgentEvent::COMPLETED, $lastEvent->type);
         self::assertSame('Partial', $lastEvent->data['fullText']);
+        self::assertCount(2, $this->agent->messages);
+        self::assertSame('assistant', $this->agent->messages[1]->role);
+        self::assertSame('Partial', $this->agent->messages[1]->content[0]['text']);
     }
 
     public function testToolDispatchException(): void

--- a/tests/Runtime/ToolListTest.php
+++ b/tests/Runtime/ToolListTest.php
@@ -24,6 +24,7 @@ final class ToolListTest extends TestCase
         $toolList = new ToolList($tools);
 
         $this->assertTrue($toolList->isConfirmable('delete_user'));
+        $this->assertTrue($toolList->has('delete_user'));
     }
 
     public function testIsConfirmableReturnsFalseForNonConfirmableTool(): void
@@ -46,6 +47,7 @@ final class ToolListTest extends TestCase
         $toolList = new ToolList([]);
 
         $this->assertFalse($toolList->isConfirmable('unknown'));
+        $this->assertFalse($toolList->has('unknown'));
     }
 
     public function testMixedConfirmableTools(): void

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(AlpsSemanticDictionary::class)]
+#[CoversClass(AlpsDescriptorIndex::class)]
 final class AlpsSemanticDictionaryTest extends TestCase
 {
     private AlpsSemanticDictionary $dictionary;
@@ -59,6 +60,21 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertNull($this->dictionary->get('createUser'));
     }
 
+    public function testGetDescriptorIncludesNonSemanticDescriptor(): void
+    {
+        $descriptor = $this->dictionary->getDescriptor('createUser');
+
+        $this->assertSame('createUser', $descriptor['id'] ?? null);
+        $this->assertSame('safe', $descriptor['type'] ?? null);
+        $this->assertSame('Create user transition', $descriptor['description'] ?? null);
+        $this->assertNull($descriptor['href'] ?? null);
+    }
+
+    public function testGetDescriptorForMissingId(): void
+    {
+        $this->assertNull($this->dictionary->getDescriptor('nonexistent'));
+    }
+
     public function testLocalHrefResolvesToReferencedDescription(): void
     {
         // userIdAlias has href="#userId" → resolves to "User identifier"
@@ -82,6 +98,10 @@ final class AlpsSemanticDictionaryTest extends TestCase
     {
         // href that does not start with '#' is not resolved (cross-file ref unsupported)
         $this->assertNull($this->dictionary->get('externalRef'));
+
+        $descriptor = $this->dictionary->getDescriptor('externalRef');
+        $this->assertSame('https://example.com/profile.json#userId', $descriptor['href'] ?? null);
+        $this->assertNull($descriptor['description'] ?? null);
     }
 
     public function testLoadXmlProfile(): void

--- a/tests/Schema/AlpsSemanticDictionaryTest.php
+++ b/tests/Schema/AlpsSemanticDictionaryTest.php
@@ -56,17 +56,17 @@ final class AlpsSemanticDictionaryTest extends TestCase
 
     public function testNonSemanticDescriptorIsExcluded(): void
     {
-        // createUser is type=safe (transition) — must NOT appear in dictionary
-        $this->assertNull($this->dictionary->get('createUser'));
+        // goUserList is type=safe (transition) — must NOT appear in dictionary
+        $this->assertNull($this->dictionary->get('goUserList'));
     }
 
     public function testGetDescriptorIncludesNonSemanticDescriptor(): void
     {
-        $descriptor = $this->dictionary->getDescriptor('createUser');
+        $descriptor = $this->dictionary->getDescriptor('goUserList');
 
-        $this->assertSame('createUser', $descriptor['id'] ?? null);
+        $this->assertSame('goUserList', $descriptor['id'] ?? null);
         $this->assertSame('safe', $descriptor['type'] ?? null);
-        $this->assertSame('Create user transition', $descriptor['description'] ?? null);
+        $this->assertSame('Open user list transition', $descriptor['description'] ?? null);
         $this->assertNull($descriptor['href'] ?? null);
     }
 
@@ -113,7 +113,7 @@ final class AlpsSemanticDictionaryTest extends TestCase
         $this->assertSame('Name of the user', $dictionary->get('userName'));
         $this->assertNull($dictionary->get('email'));
         $this->assertSame('Nested description', $dictionary->get('nestedField'));
-        $this->assertNull($dictionary->get('createUser'));
+        $this->assertNull($dictionary->get('goUserList'));
         $this->assertSame('User identifier', $dictionary->get('userIdAlias'));
         $this->assertNull($dictionary->get('danglingHref'));
         $this->assertSame('User identifier', $dictionary->get('chainA'));


### PR DESCRIPTION
## Purpose

This is a draft integration preview for the Semantic Hypermedia Agent Runtime stack.

It merges the currently stacked PRs in order so reviewers can inspect the final combined diff and CI behavior before the stack is landed into `1.x`:

1. #18 — P0 agent extension APIs
2. #19 — ALPS context processor
3. #20 — ALPS tool policy processor
4. #21 — Preserve assistant responses in agent history
5. #22 — Review hardening

Conductor issue: #24

## Important

This PR is primarily for reviewing the completed image. It does not replace the planned top-down merge procedure unless we explicitly decide to land the stack through this integration branch.

The individual PRs should still be retargeted and rechecked as described in #24 if we choose the staged landing path.

## Local validation

- `zsh -ic 'sphp85; composer validate --strict --no-check-publish'`
- `zsh -ic 'sphp85; composer tests'`

Note: PHP 8.5 still prints deprecation notices from PHPMD/PDepend dependencies, but the commands exit successfully.
